### PR TITLE
Fix some PyLint errors

### DIFF
--- a/mitogen/ansible/connection.py
+++ b/mitogen/ansible/connection.py
@@ -39,11 +39,13 @@ class Connection(ansible.plugins.connection.ConnectionBase):
         if self.connected:
             return
         self.broker = mitogen.master.Broker()
+        self.router = mitogen.master.Router(self.broker)
         if self._play_context.remote_addr == 'localhost':
-            self.context = mitogen.master.connect(self.broker)
+            self.context = self.router.connect(mitogen.master.Stream)
         else:
-            self.context = mitogen.ssh.connect(broker,
-                self._play_context.remote_addr)
+            self.context = self.router.connect(mitogen.ssh.Stream,
+                hostname=self._play_context.remote_addr,
+            )
 
     def exec_command(self, cmd, in_data=None, sudoable=True):
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)

--- a/mitogen/ansible/connection.py
+++ b/mitogen/ansible/connection.py
@@ -20,6 +20,7 @@ import mitogen.ssh
 import mitogen.utils
 from mitogen.ansible import helpers
 
+import ansible.errors
 import ansible.plugins.connection
 
 
@@ -47,7 +48,7 @@ class Connection(ansible.plugins.connection.ConnectionBase):
     def exec_command(self, cmd, in_data=None, sudoable=True):
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
         if in_data:
-            raise AnsibleError("does not support module pipelining")
+            raise ansible.errors.AnsibleError("does not support module pipelining")
 
         return self.context.call(helpers.exec_command, cmd, in_data)
 

--- a/mitogen/master.py
+++ b/mitogen/master.py
@@ -1,4 +1,6 @@
+import ast
 import commands
+import compiler
 import errno
 import getpass
 import imp

--- a/mitogen/master.py
+++ b/mitogen/master.py
@@ -1,4 +1,9 @@
-import ast
+try:
+    import ast
+except ImportError:
+    # ast module is not available in Python 2.4.x, instead we shall use the
+    # the compiler module as a fallback
+    ast = None
 import commands
 import compiler
 import errno

--- a/mitogen/master.py
+++ b/mitogen/master.py
@@ -565,6 +565,7 @@ class Stream(mitogen.core.Stream):
     # base64'd and passed to 'python -c'. It forks, dups 0->100, creates a
     # pipe, then execs a new interpreter with a custom argv. 'CONTEXT_NAME' is
     # replaced with the context name. Optimized for size.
+    @staticmethod
     def _first_stage():
         import os,sys,zlib
         R,W=os.pipe()

--- a/mitogen/ssh.py
+++ b/mitogen/ssh.py
@@ -70,6 +70,7 @@ class Stream(mitogen.master.Stream):
         if self.port:
             self.name += ':%s' % (self.port,)
 
+    auth_incorrect_msg = 'SSH authentication is incorrect'
     password_incorrect_msg = 'SSH password is incorrect'
     password_required_msg = 'SSH password was requested, but none specified'
 

--- a/mitogen/tcp.py
+++ b/mitogen/tcp.py
@@ -7,6 +7,8 @@ import socket
 
 import mitogen.core
 
+from mitogen.core import LOG
+
 
 class Listener(mitogen.core.BasicStream):
     def __init__(self, broker, address=None, backlog=30):

--- a/mitogen/tcp.py
+++ b/mitogen/tcp.py
@@ -21,7 +21,7 @@ class Listener(mitogen.core.BasicStream):
 
     def on_receive(self, broker):
         sock, addr = self._sock.accept()
-        context = Context(self._broker, name=addr)
+        context = mitogen.core.Context(self._broker, name=addr)
         stream = mitogen.core.Stream(context)
         stream.accept(sock.fileno(), sock.fileno())
 

--- a/mitogen/utils.py
+++ b/mitogen/utils.py
@@ -45,7 +45,7 @@ def log_to_file(path=None, io=True, level='INFO'):
 
 
 def run_with_router(func, *args, **kwargs):
-    """Arrange for `func(broker, *args, **kwargs)` to run with a temporary
+    """Arrange for `func(router, *args, **kwargs)` to run with a temporary
     :py:class:`mitogen.master.Router`, ensuring the Router and Broker are
     correctly shut down during normal or exceptional return."""
     broker = mitogen.master.Broker()
@@ -58,12 +58,12 @@ def run_with_router(func, *args, **kwargs):
 
 
 def with_router(func):
-    """Decorator version of :py:func:`run_with_broker`. Example:
+    """Decorator version of :py:func:`run_with_router`. Example:
 
     .. code-block:: python
 
-        @with_broker
-        def do_stuff(broker, arg):
+        @with_router
+        def do_stuff(router, arg):
             pass
 
         do_stuff(blah, 123)

--- a/tests/timing_test.py
+++ b/tests/timing_test.py
@@ -8,9 +8,9 @@ import mitogen.master
 import mitogen.utils
 
 
-@mitogen.utils.with_broker
-def do_stuff(broker):
-    context = mitogen.master.connect(broker)
+@mitogen.utils.with_router
+def do_stuff(router):
+    context = router.connect(mitogen.master.Stream)
     t0 = time.time()
     ncalls = 1000
     for x in xrange(ncalls):

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -6,27 +6,27 @@ import mitogen.master
 import mitogen.utils
 
 
-def func0(broker):
-    return broker
+def func0(router):
+    return router
 
 
-@mitogen.utils.with_broker
-def func(broker):
-    return broker
+@mitogen.utils.with_router
+def func(router):
+    return router
 
 
-class RunWithBrokerTest(unittest.TestCase):
+class RunWithRouterTest(unittest.TestCase):
     # test_shutdown_on_exception
     # test_shutdown_on_success
 
     def test_run_with_broker(self):
-        broker = mitogen.utils.run_with_broker(func0)
-        self.assertTrue(isinstance(broker, mitogen.master.Broker))
-        self.assertFalse(broker._thread.isAlive())
+        router = mitogen.utils.run_with_router(func0)
+        self.assertTrue(isinstance(router, mitogen.master.Router))
+        self.assertFalse(router.broker._thread.isAlive())
 
 
-class WithBrokerTest(unittest.TestCase):
+class WithRouterTest(unittest.TestCase):
     def test_with_broker(self):
-        broker = func()
-        self.assertTrue(isinstance(broker, mitogen.master.Broker))
-        self.assertFalse(broker._thread.isAlive())
+        router = func()
+        self.assertTrue(isinstance(router, mitogen.master.Router))
+        self.assertFalse(router.broker._thread.isAlive())


### PR DESCRIPTION
Hope these changes aren't too presumptuous. This doesn't fix all the errors found, just the ones that seemed contentious to me. I also included some test suite updates. Here's the output before and after

### Before

```
************* Module mitogen.master
E:347,20: Undefined variable 'ast' (undefined-variable)
E:347,29: Undefined variable 'ast' (undefined-variable)
E:348,32: Undefined variable 'ast' (undefined-variable)
E:351,34: Undefined variable 'ast' (undefined-variable)
E:366,41: Undefined variable 'compiler' (undefined-variable)
E:367,32: Undefined variable 'compiler' (undefined-variable)
E:370,34: Undefined variable 'compiler' (undefined-variable)
E:395,11: Undefined variable 'ast' (undefined-variable)
E:566, 4: Method has no argument (no-method-argument)
************* Module mitogen.ssh
E: 87,40: Instance of 'Stream' has no 'auth_incorrect_msg' member (no-member)
************* Module mitogen.tcp
E: 24,18: Undefined variable 'Context' (undefined-variable)
E: 25,17: No value for argument 'remote_id' in constructor call (no-value-for-parameter)
E: 37, 4: Undefined variable 'LOG' (undefined-variable)
E: 39, 4: Undefined variable 'self' (undefined-variable)
E: 39,42: Undefined variable 'self' (undefined-variable)
E: 40, 4: Undefined variable 'self' (undefined-variable)
E: 40,43: Undefined variable 'self' (undefined-variable)
E: 41,17: Undefined variable 'self' (undefined-variable)
E: 42, 4: Undefined variable 'self' (undefined-variable)
E: 42,20: Undefined variable 'self' (undefined-variable)
************* Module mitogen.ansible.connection
E: 42,27: Module 'mitogen.master' has no 'connect' member (no-member)
E: 44,27: Module 'mitogen.ssh' has no 'connect' member (no-member)
E: 44,47: Undefined variable 'broker' (undefined-variable)
E: 50,18: Undefined variable 'AnsibleError' (undefined-variable)
************* Module mitogen.compat.pkgutil
E: 44,16: class already defined line 37 (function-redefined)
```

### After

```
************* Module mitogen.tcp
E: 26,18: No value for argument 'context_id' in constructor call (no-value-for-parameter)
E: 27,17: No value for argument 'remote_id' in constructor call (no-value-for-parameter)
E: 41, 4: Undefined variable 'self' (undefined-variable)
E: 41,42: Undefined variable 'self' (undefined-variable)
E: 42, 4: Undefined variable 'self' (undefined-variable)
E: 42,43: Undefined variable 'self' (undefined-variable)
E: 43,17: Undefined variable 'self' (undefined-variable)
E: 44, 4: Undefined variable 'self' (undefined-variable)
E: 44,20: Undefined variable 'self' (undefined-variable)
************* Module mitogen.compat.pkgutil
E: 44,16: class already defined line 37 (function-redefined)
```
