### PR TITLE
Fix "hook uses deprecated __multicall__ argument" warning

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,5 +2,5 @@
 ansible==2.3.1.0
 docker==2.5.1
 docker[tls]==2.5.1
-pytest-capturelog==0.7
+pytest-catchlog==1.2.2
 pytest==3.1.2


### PR DESCRIPTION
By replacing pytest-capturelog with pytest-catchlog we fix one warning that is reported by pytest:

```
venv/local/lib/python2.7/site-packages/pytest_capturelog.py:171
'pytest_runtest_makereport' hook uses deprecated __multicall__
argument

None
pytest_funcarg__caplog: declaring fixtures using "pytest_funcarg__"
prefix is deprecated and scheduled to be removed in pytest 4.0.  Please
remove the prefix and use the @pytest.fixture decorator instead.
pytest_funcarg__capturelog: declaring fixtures using
"pytest_funcarg__" prefix is deprecated and scheduled to be removed in
pytest 4.0.  Please remove the prefix and use the @pytest.fixture
decorator instead.

-- Docs: http://doc.pytest.org/en/latest/warnings.html
```

pytest-capturelog seems to be unmaintained, the bug in question <https://bitbucket.org/memedough/pytest-capturelog/issues/6> has been open since July 2015. pytest-catchlog is a fork of pytest-capturelog.