### PR TITLE
Add mock requirement

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,5 +2,6 @@
 ansible==2.3.1.0
 docker==2.5.1
 docker[tls]==2.5.1
+mock==2.0.0
 pytest-catchlog==1.2.2
 pytest==3.1.2


### PR DESCRIPTION
Mock is required to run the tests. Otherwise these errors occur under pytest

```
================================================ ERRORS =================================================
________________________________ ERROR collecting tests/importer_test.py ________________________________
ImportError while importing test module '/home/alex/src/mitogen/tests/importer_test.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
tests/importer_test.py:8: in <module>
    import mock
E   ImportError: No module named mock
_______________________________ ERROR collecting tests/responder_test.py ________________________________
ImportError while importing test module '/home/alex/src/mitogen/tests/responder_test.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
tests/responder_test.py:2: in <module>
    import mock
E   ImportError: No module named mock
```