### PR TITLE
Setup: fix package name and add Trove classifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+build/
+dist/
 docs/_build
 *.egg-info

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(
     author = 'David Wilson',
     license = 'OpenLDAP BSD',
     url = 'http://github.com/dw/mitogen/',
-    py_packages = ['Mitogen'],
+    packages = ['mitogen'],
     zip_safe = False
 )

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 
 from distutils.core import setup
 

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,21 @@ setup(
     license = 'OpenLDAP BSD',
     url = 'http://github.com/dw/mitogen/',
     packages = ['mitogen'],
-    zip_safe = False
+    zip_safe = False,
+    classifiers = [
+        'Development Status :: 3 - Alpha',
+        'Environment :: Console',
+        'Intended Audience :: System Administrators',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: POSIX',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.4',
+        'Programming Language :: Python :: 2.5',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 2 :: Only',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Topic :: System :: Distributed Computing',
+        'Topic :: System :: Systems Administration',
+    ],
 )


### PR DESCRIPTION
I've been running with these changes (uncommitted), they've made installing inside a virtualenv and running the test suite much easier. e.g.

```bash
cd src/mitogen/
virtualenv venv
source venv/bin/activate
pip install -e .
pip install -r dev_requirements.txt
pytest
```

Fixes #43 