### PR TITLE
testlib: Auto negotiate Docker API version

### DIFF
--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -42,7 +42,7 @@ class TestCase(unittest.TestCase):
 
 class DockerizedSshDaemon(object):
     def __init__(self):
-        self.docker = docker.from_env()
+        self.docker = docker.from_env(version='auto')
         self.container_name = 'mitogen-test-%08x' % (random.getrandbits(64),)
         self.container = self.docker.containers.run(
             image='d2mw/mitogen-test',


### PR DESCRIPTION
Ubuntu 17.04 provides Docker 1.12.6, which has API version 1.24. `dev_requirements.txt` specifies the docker-py 2.5.1, which by default requests API version 1.30.

Hence when the SSH unit tests try to run the container specified in `DockerizedSshDaemon` an error occurs

```
APIError: 400 Client Error: Bad Request ("client is newer than server (client API version: 1.30, server API version: 1.24)")
```