### PR TITLE
tests: Fix GetModuleViaPkgutilTest fetching .pyc

### DIFF
--- a/tests/module_finder_test.py
+++ b/tests/module_finder_test.py
@@ -1,5 +1,6 @@
-
+import inspect
 import unittest
+
 import mitogen.master
 
 import testlib
@@ -74,7 +75,7 @@ class GetModuleViaPkgutilTest(testlib.TestCase):
         path, src, is_pkg = self.call('module_finder_testmod.regular_mod')
         self.assertEquals(path,
             testlib.data_path('module_finder_testmod/regular_mod.py'))
-        self.assertEquals(src, file(regular_mod.__file__).read())
+        self.assertEquals(src, inspect.getsource(regular_mod))
         self.assertFalse(is_pkg)
 
 


### PR DESCRIPTION
On my laptop (Ubuntu 17.10, Python 2.7.14 in a virtualenv), `test_regular_mod` fails with

```
AssertionError: "\nimport sys\n\n\ndef say_hi():\n    print 'hi'\n" !=
'\x03\xf3\r\n\xbbW\xd5Yc\x00\x00\x00\x00\x00\x00 ... /home/alex/src/mitogen/tests/data/module_finder_testmod/regular_mod.pyt\x08\x00\x00\x00<module>\x02\x00\x00\x00s\x02\x00\x00\x00\x0c\x03'
```

`__file__` contains the path of the compiled `.pyc`, not the `.py` source file that this test expects.