### PR TITLE
fakessh: Remove colon causing SyntaxError

### DIFF
--- a/mitogen/fakessh.py
+++ b/mitogen/fakessh.py
@@ -165,7 +165,7 @@ class Process(object):
             # variants of libc thread operations cannot be interrupted e.g. via
             # KeyboardInterrupt. isSet() test and wait() are separate since in
             # <2.7 wait() always returns None.
-            self.wake_event.wait(0.1):
+            self.wake_event.wait(0.1)
 
 
 @mitogen.core.takes_router


### PR DESCRIPTION
fixes #58