### PR TITLE
[PyCon UK 2017 Sprint] Describe the installation and test process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,7 @@ install:
 - pip install -r dev_requirements.txt
 
 script:
-- PYTHONPATH=. timeout 05.0 python tests/call_function_test.py
-- PYTHONPATH=. timeout 05.0 python tests/channel_test.py
-- PYTHONPATH=. timeout 05.0 python tests/first_stage_test.py
-- PYTHONPATH=. timeout 05.0 python tests/id_allocation_test.py
-- PYTHONPATH=. timeout 05.0 python tests/importer_test.py
-- PYTHONPATH=. timeout 05.0 python tests/local_test.py
-- PYTHONPATH=. timeout 05.0 python tests/master_test.py
-- PYTHONPATH=. timeout 05.0 python tests/module_finder_test.py
-- PYTHONPATH=. timeout 05.0 python tests/nested_test.py
-- PYTHONPATH=. timeout 05.0 python tests/responder_test.py
-- PYTHONPATH=. timeout 05.0 python tests/utils_test.py
-- PYTHONPATH=. timeout 20.0 python tests/select_test.py
-- PYTHONPATH=. timeout 20.0 python tests/ssh_test.py
-- PYTHONPATH=. timeout 30.0 python tests/fakessh_test.py
+- PYTHONPATH=. timeout 05.0 ${TRAVIS_BUILD_DIR}/test.sh
 
 services:
   - docker

--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@ containers, e.g. it should not be firewalled or port forwarded.
 
 If in doubt, just install Docker on a Linux box in the default configuration
 and run the tests there.
+
+## Steps To Prepare Development Environment
+
+1. Get the code ``git clone https://github.com/dw/mitogen.git``
+1. Go into the working directory ``cd mitogen``
+1. Establish the docker image ``./tests/build_docker_image.py``
+1. Build the virtual environment ``virtualenv ../venv``
+1. Enable the virtual environment we just built ``source ../venv/bin/activate``
+1. Install Mitogen in pip editable mode ``pip install -e .``
+1. Run ``test.sh``

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+timeout 05.0 python tests/call_function_test.py
+timeout 05.0 python tests/channel_test.py
+timeout 05.0 python tests/first_stage_test.py
+timeout 05.0 python tests/id_allocation_test.py
+timeout 05.0 python tests/importer_test.py
+timeout 05.0 python tests/local_test.py
+timeout 05.0 python tests/master_test.py
+timeout 05.0 python tests/module_finder_test.py
+timeout 05.0 python tests/nested_test.py
+timeout 05.0 python tests/responder_test.py
+timeout 05.0 python tests/utils_test.py
+timeout 20.0 python tests/select_test.py
+timeout 20.0 python tests/ssh_test.py
+timeout 30.0 python tests/fakessh_test.py


### PR DESCRIPTION
With love from PyconUK 2017 sprints!

We use test.sh to consolidate test cases in one file so the README
would not be outdated easier rather than the hard-coded test commands
in a code block.

The travis build failure is the same as the original one. It is not a regression.

```
unsocks <module 'six' from '/home/travis/virtualenv/python2.7.13/lib/python2.7/site-packages/six.pyc'>
F....
======================================================================
FAIL: test_ansible_six_messed_up_path (__main__.BrokenModulesTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/responder_test.py", line 77, in test_ansible_six_messed_up_path
    self.assertTrue(isinstance(msg.unpickle(), tuple))
AssertionError: False is not true
----------------------------------------------------------------------
Ran 5 tests in 0.353s
FAILED (failures=1)
```