### PR TITLE
Use unittest2 and specific assertX methods

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,3 +5,4 @@ docker[tls]==2.5.1
 mock==2.0.0
 pytest-catchlog==1.2.2
 pytest==3.1.2
+unittest2=1.1.0

--- a/tests/call_function_test.py
+++ b/tests/call_function_test.py
@@ -39,7 +39,7 @@ class CallFunctionTest(testlib.RouterMixin, testlib.TestCase):
         self.local = self.router.local()
 
     def test_succeeds(self):
-        assert 3 == self.local.call(function_that_adds_numbers, 1, 2)
+        self.assertEqual(3, self.local.call(function_that_adds_numbers, 1, 2))
 
     def test_crashes(self):
         exc = self.assertRaises(mitogen.core.CallError,
@@ -47,13 +47,13 @@ class CallFunctionTest(testlib.RouterMixin, testlib.TestCase):
 
         s = str(exc)
         etype, _, s = s.partition(': ')
-        assert etype == 'exceptions.ValueError'
+        self.assertEqual(etype, 'exceptions.ValueError')
 
         msg, _, s = s.partition('\n')
-        assert msg == 'exception text'
+        self.assertEqual(msg, 'exception text')
 
         # Traceback
-        assert len(s) > 0
+        self.assertGreater(len(s), 0)
 
     def test_bad_return_value(self):
         exc = self.assertRaises(mitogen.core.StreamError,
@@ -61,7 +61,7 @@ class CallFunctionTest(testlib.RouterMixin, testlib.TestCase):
         self.assertEquals(exc[0], "cannot unpickle '__main__'/'CrazyType'")
 
     def test_returns_dead(self):
-        assert mitogen.core._DEAD == self.local.call(func_returns_dead)
+        self.assertEqual(mitogen.core._DEAD, self.local.call(func_returns_dead))
 
     def test_aborted_on_local_context_disconnect(self):
         stream = self.router._stream_by_id[self.local.context_id]
@@ -83,9 +83,9 @@ class CallFunctionTest(testlib.RouterMixin, testlib.TestCase):
 
     def test_accepts_returns_context(self):
         context = self.local.call(func_accepts_returns_context, self.local)
-        assert context is not self.local
-        assert context.context_id == self.local.context_id
-        assert context.name == self.local.name
+        self.assertIsNot(context, self.local)
+        self.assertEqual(context.context_id, self.local.context_id)
+        self.assertEqual(context.name, self.local.name)
 
 
 if __name__ == '__main__':

--- a/tests/call_function_test.py
+++ b/tests/call_function_test.py
@@ -1,6 +1,7 @@
 import logging
 import time
-import unittest
+
+import unittest2 as unittest
 
 import mitogen.core
 import mitogen.master

--- a/tests/call_function_test.py
+++ b/tests/call_function_test.py
@@ -1,7 +1,7 @@
 import logging
 import time
 
-import unittest2 as unittest
+import unittest2
 
 import mitogen.core
 import mitogen.master
@@ -89,4 +89,4 @@ class CallFunctionTest(testlib.RouterMixin, testlib.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest2.main()

--- a/tests/channel_test.py
+++ b/tests/channel_test.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest2
 
 import mitogen.core
 import testlib
@@ -17,4 +17,4 @@ class ConstructorTest(testlib.RouterMixin, testlib.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest2.main()

--- a/tests/channel_test.py
+++ b/tests/channel_test.py
@@ -9,11 +9,11 @@ class ConstructorTest(testlib.RouterMixin, testlib.TestCase):
         # issue 32
         l1 = self.router.local()
         chan = mitogen.core.Channel(self.router, l1, 123)
-        assert chan.router == self.router
-        assert chan.context == l1
-        assert chan.dst_handle == 123
-        assert chan.handle is not None
-        assert chan.handle > 0
+        self.assertEqual(chan.router, self.router)
+        self.assertEqual(chan.context, l1)
+        self.assertEqual(chan.dst_handle, 123)
+        self.assertIsNotNone(chan.handle)
+        self.assertGreater(chan.handle, 0)
 
 
 if __name__ == '__main__':

--- a/tests/channel_test.py
+++ b/tests/channel_test.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest2 as unittest
 
 import mitogen.core
 import testlib

--- a/tests/fakessh_test.py
+++ b/tests/fakessh_test.py
@@ -1,7 +1,8 @@
 
 import os
 import shutil
-import unittest
+
+import unittest2 as unittest
 
 import mitogen.fakessh
 

--- a/tests/fakessh_test.py
+++ b/tests/fakessh_test.py
@@ -21,9 +21,9 @@ class RsyncTest(testlib.DockerMixin, unittest.TestCase):
             testlib.data_path('.'), 'target:/tmp/data'
         ])
 
-        assert return_code == 0
-        assert context.call(os.path.exists, '/tmp/data')
-        assert context.call(os.path.exists, '/tmp/data/simple_pkg/a.py')
+        self.assertEqual(return_code, 0)
+        self.assertTrue(context.call(os.path.exists, '/tmp/data'))
+        self.assertTrue(context.call(os.path.exists, '/tmp/data/simple_pkg/a.py'))
 
     def test_rsync_between_direct_children(self):
         # master -> SSH -> has-sudo-pubkey -> rsync(.ssh) -> master ->
@@ -52,9 +52,11 @@ class RsyncTest(testlib.DockerMixin, unittest.TestCase):
             'rsync', '--progress', '-vvva', '.ssh/', 'target:' + dest_path
         ])
 
-        assert return_code == 0
-        assert pubkey_acct.call(os.path.getsize, '.ssh/authorized_keys') == \
-               webapp_acct.call(os.path.getsize, dest_path + '/authorized_keys')
+        self.assertEqual(return_code, 0)
+        self.assertEqual(
+            pubkey_acct.call(os.path.getsize, '.ssh/authorized_keys'),
+            webapp_acct.call(os.path.getsize, dest_path + '/authorized_keys'),
+        )
 
 
 if __name__ == '__main__':

--- a/tests/fakessh_test.py
+++ b/tests/fakessh_test.py
@@ -2,14 +2,14 @@
 import os
 import shutil
 
-import unittest2 as unittest
+import unittest2
 
 import mitogen.fakessh
 
 import testlib
 
 
-class RsyncTest(testlib.DockerMixin, unittest.TestCase):
+class RsyncTest(testlib.DockerMixin, unittest2.TestCase):
     def test_rsync_from_master(self):
         context = self.docker_ssh_any()
 
@@ -60,4 +60,4 @@ class RsyncTest(testlib.DockerMixin, unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest2.main()

--- a/tests/first_stage_test.py
+++ b/tests/first_stage_test.py
@@ -1,7 +1,7 @@
 
 import subprocess
 
-import unittest2 as unittest
+import unittest2
 
 import mitogen.master
 import testlib
@@ -40,4 +40,4 @@ class CommandLineTest(testlib.RouterMixin, testlib.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest2.main()

--- a/tests/first_stage_test.py
+++ b/tests/first_stage_test.py
@@ -36,7 +36,7 @@ class CommandLineTest(testlib.RouterMixin, testlib.TestCase):
         stdout, stderr = proc.communicate()
         self.assertEquals(0, proc.returncode)
         self.assertEquals("EC0\n", stdout)
-        self.assertContains("EOFError", stderr)
+        self.assertIn("EOFError", stderr)
 
 
 if __name__ == '__main__':

--- a/tests/first_stage_test.py
+++ b/tests/first_stage_test.py
@@ -1,6 +1,7 @@
 
 import subprocess
-import unittest
+
+import unittest2 as unittest
 
 import mitogen.master
 import testlib

--- a/tests/id_allocation_test.py
+++ b/tests/id_allocation_test.py
@@ -1,5 +1,5 @@
 
-import unittest
+import unittest2 as unittest
 
 import testlib
 import id_allocation

--- a/tests/id_allocation_test.py
+++ b/tests/id_allocation_test.py
@@ -9,7 +9,7 @@ class SlaveTest(testlib.RouterMixin, testlib.TestCase):
     def test_slave_allocates_id(self):
         context = self.router.local()
         id_ = context.call(id_allocation.allocate_an_id)
-        assert id_ == (self.router.id_allocator.next_id - 1)
+        self.assertEqual(id_, self.router.id_allocator.next_id - 1)
 
 
 if __name__ == '__main__':

--- a/tests/id_allocation_test.py
+++ b/tests/id_allocation_test.py
@@ -1,5 +1,5 @@
 
-import unittest2 as unittest
+import unittest2
 
 import testlib
 import id_allocation
@@ -13,4 +13,4 @@ class SlaveTest(testlib.RouterMixin, testlib.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest2.main()

--- a/tests/importer_test.py
+++ b/tests/importer_test.py
@@ -6,7 +6,7 @@ import zlib
 
 import mock
 import pytest
-import unittest2 as unittest
+import unittest2
 
 import mitogen.core
 import testlib
@@ -128,4 +128,4 @@ class EmailParseAddrSysTest(testlib.RouterMixin, testlib.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest2.main()

--- a/tests/importer_test.py
+++ b/tests/importer_test.py
@@ -2,11 +2,11 @@
 import email.utils
 import sys
 import types
-import unittest
 import zlib
 
 import mock
 import pytest
+import unittest2 as unittest
 
 import mitogen.core
 import testlib

--- a/tests/importer_test.py
+++ b/tests/importer_test.py
@@ -39,8 +39,8 @@ class LoadModuleTest(ImporterMixin, testlib.TestCase):
     def test_module_added_to_sys_modules(self):
         self.context.send_await.return_value = self.response
         mod = self.importer.load_module(self.modname)
-        self.assertTrue(sys.modules[self.modname] is mod)
-        self.assertTrue(isinstance(mod, types.ModuleType))
+        self.assertIs(sys.modules[self.modname], mod)
+        self.assertIsInstance(mod, types.ModuleType)
 
     def test_module_file_set(self):
         self.context.send_await.return_value = self.response
@@ -50,12 +50,12 @@ class LoadModuleTest(ImporterMixin, testlib.TestCase):
     def test_module_loader_set(self):
         self.context.send_await.return_value = self.response
         mod = self.importer.load_module(self.modname)
-        self.assertTrue(mod.__loader__ is self.importer)
+        self.assertIs(mod.__loader__, self.importer)
 
     def test_module_package_unset(self):
         self.context.send_await.return_value = self.response
         mod = self.importer.load_module(self.modname)
-        self.assertTrue(mod.__package__ is None)
+        self.assertIsNone(mod.__package__)
 
 
 class LoadSubmoduleTest(ImporterMixin, testlib.TestCase):
@@ -96,7 +96,7 @@ class LoadModulePackageTest(ImporterMixin, testlib.TestCase):
     def test_module_loader_set(self):
         self.context.send_await.return_value = self.response
         mod = self.importer.load_module(self.modname)
-        self.assertTrue(mod.__loader__ is self.importer)
+        self.assertIs(mod.__loader__, self.importer)
 
     def test_module_path_present(self):
         self.context.send_await.return_value = self.response
@@ -111,7 +111,7 @@ class LoadModulePackageTest(ImporterMixin, testlib.TestCase):
     def test_module_data(self):
         self.context.send_await.return_value = self.response
         mod = self.importer.load_module(self.modname)
-        self.assertTrue(isinstance(mod.func, types.FunctionType))
+        self.assertIsInstance(mod.func, types.FunctionType)
         self.assertEquals(mod.func.__module__, self.modname)
 
 

--- a/tests/local_test.py
+++ b/tests/local_test.py
@@ -1,7 +1,7 @@
 
 import os
 
-import unittest2 as unittest
+import unittest2
 
 import mitogen
 import mitogen.ssh
@@ -11,7 +11,7 @@ import testlib
 import plain_old_module
 
 
-class LocalTest(testlib.RouterMixin, unittest.TestCase):
+class LocalTest(testlib.RouterMixin, unittest2.TestCase):
     stream_class = mitogen.ssh.Stream
 
     def test_stream_name(self):
@@ -21,4 +21,4 @@ class LocalTest(testlib.RouterMixin, unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest2.main()

--- a/tests/local_test.py
+++ b/tests/local_test.py
@@ -1,6 +1,7 @@
 
 import os
-import unittest
+
+import unittest2 as unittest
 
 import mitogen
 import mitogen.ssh

--- a/tests/master_test.py
+++ b/tests/master_test.py
@@ -36,7 +36,7 @@ class IterReadTest(unittest.TestCase):
         try:
             reader = self.func(proc.stdout.fileno())
             for i, chunk in enumerate(reader, 1):
-                assert i == int(chunk)
+                self.assertEqual(i, int(chunk))
                 if i > 3:
                     break
         finally:
@@ -52,7 +52,7 @@ class IterReadTest(unittest.TestCase):
                     got.append(chunk)
                 assert 0, 'TimeoutError not raised'
             except mitogen.core.TimeoutError:
-                assert len(got) == 0
+                self.assertEqual(len(got), 0)
         finally:
             proc.terminate()
 
@@ -68,7 +68,8 @@ class IterReadTest(unittest.TestCase):
             except mitogen.core.TimeoutError:
                 # Give a little wiggle room in case of imperfect scheduling.
                 # Ideal number should be 9.
-                assert 3 < len(got) < 5
+                self.assertLess(3, len(got))
+                self.assertLess(len(got), 5)
         finally:
             proc.terminate()
 

--- a/tests/master_test.py
+++ b/tests/master_test.py
@@ -2,13 +2,13 @@
 import subprocess
 import time
 
-import unittest2 as unittest
+import unittest2
 
 import testlib
 import mitogen.master
 
 
-class ScanCodeImportsTest(unittest.TestCase):
+class ScanCodeImportsTest(unittest2.TestCase):
     func = staticmethod(mitogen.master.scan_code_imports)
 
     def test_simple(self):
@@ -22,7 +22,7 @@ class ScanCodeImportsTest(unittest.TestCase):
         ])
 
 
-class IterReadTest(unittest.TestCase):
+class IterReadTest(unittest2.TestCase):
     func = staticmethod(mitogen.master.iter_read)
 
     def make_proc(self):
@@ -74,7 +74,7 @@ class IterReadTest(unittest.TestCase):
             proc.terminate()
 
 
-class WriteAllTest(unittest.TestCase):
+class WriteAllTest(unittest2.TestCase):
     func = staticmethod(mitogen.master.write_all)
 
     def make_proc(self):
@@ -115,4 +115,4 @@ class WriteAllTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest2.main()

--- a/tests/master_test.py
+++ b/tests/master_test.py
@@ -1,7 +1,8 @@
 
 import subprocess
 import time
-import unittest
+
+import unittest2 as unittest
 
 import testlib
 import mitogen.master
@@ -15,7 +16,7 @@ class ScanCodeImportsTest(unittest.TestCase):
         self.assertEquals(list(self.func(co)), [
             (-1, 'subprocess', ()),
             (-1, 'time', ()),
-            (-1, 'unittest', ()),
+            (-1, 'unittest2', ()),
             (-1, 'testlib', ()),
             (-1, 'mitogen.master', ()),
         ])

--- a/tests/module_finder_test.py
+++ b/tests/module_finder_test.py
@@ -97,12 +97,12 @@ class GetModuleViaSysModulesTest(testlib.TestCase):
         # _socket comes from a .so
         import _socket
         tup = self.call('_socket')
-        self.assertEquals(None, tup)
+        self.assertIsNone(tup)
 
     def test_builtin_fails(self):
         # sys is built-in
         tup = self.call('sys')
-        self.assertEquals(None, tup)
+        self.assertIsNone(tup)
 
 
 class ResolveRelPathTest(testlib.TestCase):

--- a/tests/module_finder_test.py
+++ b/tests/module_finder_test.py
@@ -1,6 +1,6 @@
 import inspect
 
-import unittest2 as unittest
+import unittest2
 
 import mitogen.master
 
@@ -146,4 +146,4 @@ class FindRelatedImportsTest(testlib.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest2.main()

--- a/tests/module_finder_test.py
+++ b/tests/module_finder_test.py
@@ -1,5 +1,6 @@
 import inspect
-import unittest
+
+import unittest2 as unittest
 
 import mitogen.master
 

--- a/tests/nested_test.py
+++ b/tests/nested_test.py
@@ -1,6 +1,6 @@
 import os
 
-import unittest2 as unittest
+import unittest2
 
 import testlib
 
@@ -17,4 +17,4 @@ class NestedTest(testlib.RouterMixin, testlib.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest2.main()

--- a/tests/nested_test.py
+++ b/tests/nested_test.py
@@ -13,7 +13,7 @@ class NestedTest(testlib.RouterMixin, testlib.TestCase):
             context = self.router.local(via=context, name='local%d' % x)
 
         pid = context.call(os.getpid)
-        self.assertTrue(isinstance(pid, int))
+        self.assertIsInstance(pid, int)
 
 
 if __name__ == '__main__':

--- a/tests/nested_test.py
+++ b/tests/nested_test.py
@@ -1,5 +1,6 @@
 import os
-import unittest
+
+import unittest2 as unittest
 
 import testlib
 

--- a/tests/responder_test.py
+++ b/tests/responder_test.py
@@ -3,7 +3,7 @@ import mock
 import subprocess
 import sys
 
-import unittest2 as unittest
+import unittest2
 
 import mitogen.master
 import testlib
@@ -12,7 +12,7 @@ import plain_old_module
 import simple_pkg.a
 
 
-class GoodModulesTest(testlib.RouterMixin, unittest.TestCase):
+class GoodModulesTest(testlib.RouterMixin, unittest2.TestCase):
     def test_plain_old_module(self):
         # The simplest case: a top-level module with no interesting imports or
         # package machinery damage.
@@ -34,7 +34,7 @@ class GoodModulesTest(testlib.RouterMixin, unittest.TestCase):
         self.assertEquals(output, "['__main__', 50]\n")
 
 
-class BrokenModulesTest(unittest.TestCase):
+class BrokenModulesTest(unittest2.TestCase):
     def test_obviously_missing(self):
         # Ensure we don't crash in the case of a module legitimately being
         # unavailable. Should never happen in the real world.
@@ -79,4 +79,4 @@ class BrokenModulesTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest2.main()

--- a/tests/responder_test.py
+++ b/tests/responder_test.py
@@ -52,7 +52,7 @@ class BrokenModulesTest(unittest.TestCase):
         call = router.route.mock_calls[0]
         msg, = call[1]
         self.assertEquals(50, msg.handle)
-        self.assertTrue(msg.unpickle() is None)
+        self.assertIsNone(msg.unpickle())
 
     def test_ansible_six_messed_up_path(self):
         # The copy of six.py shipped with Ansible appears in a package whose
@@ -75,7 +75,7 @@ class BrokenModulesTest(unittest.TestCase):
         call = router.route.mock_calls[0]
         msg, = call[1]
         self.assertEquals(50, msg.handle)
-        self.assertTrue(isinstance(msg.unpickle(), tuple))
+        self.assertIsInstance(msg.unpickle(), tuple)
 
 
 if __name__ == '__main__':

--- a/tests/responder_test.py
+++ b/tests/responder_test.py
@@ -1,8 +1,9 @@
 
 import mock
 import subprocess
-import unittest
 import sys
+
+import unittest2 as unittest
 
 import mitogen.master
 import testlib

--- a/tests/select_test.py
+++ b/tests/select_test.py
@@ -1,5 +1,6 @@
 
-import unittest
+import unittest2 as unittest
+
 import mitogen.master
 
 import testlib

--- a/tests/select_test.py
+++ b/tests/select_test.py
@@ -1,5 +1,5 @@
 
-import unittest2 as unittest
+import unittest2
 
 import mitogen.master
 
@@ -262,4 +262,4 @@ class GetTest(testlib.RouterMixin, testlib.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest2.main()

--- a/tests/ssh_test.py
+++ b/tests/ssh_test.py
@@ -53,7 +53,7 @@ class SshTest(testlib.DockerMixin, unittest.TestCase):
         except mitogen.ssh.PasswordError, e:
             pass
 
-        assert e[0] == self.stream_class.password_required_msg
+        self.assertEqual(e[0], self.stream_class.password_required_msg)
 
     def test_password_incorrect(self):
         try:
@@ -65,7 +65,7 @@ class SshTest(testlib.DockerMixin, unittest.TestCase):
         except mitogen.ssh.PasswordError, e:
             pass
 
-        assert e[0] == self.stream_class.password_incorrect_msg
+        self.assertEqual(e[0], self.stream_class.password_incorrect_msg)
 
     def test_password_specified(self):
         context = self.docker_ssh(
@@ -73,8 +73,10 @@ class SshTest(testlib.DockerMixin, unittest.TestCase):
             password='y',
         )
 
-        sentinel = 'i-am-mitogen-test-docker-image\n'
-        assert sentinel == context.call(plain_old_module.get_sentinel_value)
+        self.assertEqual(
+            'i-am-mitogen-test-docker-image\n',
+            context.call(plain_old_module.get_sentinel_value),
+        )
 
     def test_pubkey_required(self):
         try:
@@ -85,15 +87,17 @@ class SshTest(testlib.DockerMixin, unittest.TestCase):
         except mitogen.ssh.PasswordError, e:
             pass
 
-        assert e[0] == self.stream_class.password_required_msg
+        self.assertEqual(e[0], self.stream_class.password_required_msg)
 
     def test_pubkey_specified(self):
         context = self.docker_ssh(
             username='has-sudo-pubkey',
             identity_file=testlib.data_path('docker/has-sudo-pubkey.key'),
         )
-        sentinel = 'i-am-mitogen-test-docker-image\n'
-        assert sentinel == context.call(plain_old_module.get_sentinel_value)
+        self.assertEqual(
+            'i-am-mitogen-test-docker-image\n',
+            context.call(plain_old_module.get_sentinel_value),
+        )
 
 
 if __name__ == '__main__':

--- a/tests/ssh_test.py
+++ b/tests/ssh_test.py
@@ -2,13 +2,13 @@ import mitogen
 import mitogen.ssh
 import mitogen.utils
 
-import unittest2 as unittest
+import unittest2
 
 import testlib
 import plain_old_module
 
 
-class FakeSshTest(testlib.RouterMixin, unittest.TestCase):
+class FakeSshTest(testlib.RouterMixin, unittest2.TestCase):
     def test_okay(self):
         context = self.router.ssh(
                 hostname='hostname',
@@ -20,7 +20,7 @@ class FakeSshTest(testlib.RouterMixin, unittest.TestCase):
         self.assertEquals(3, context.call(plain_old_module.add, 1, 2))
 
 
-class SshTest(testlib.DockerMixin, unittest.TestCase):
+class SshTest(testlib.DockerMixin, unittest2.TestCase):
     stream_class = mitogen.ssh.Stream
 
     def test_stream_name(self):
@@ -101,4 +101,4 @@ class SshTest(testlib.DockerMixin, unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest2.main()

--- a/tests/ssh_test.py
+++ b/tests/ssh_test.py
@@ -1,9 +1,8 @@
-
-import unittest
-
 import mitogen
 import mitogen.ssh
 import mitogen.utils
+
+import unittest2 as unittest
 
 import testlib
 import plain_old_module

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -5,8 +5,9 @@ import re
 import socket
 import sys
 import time
-import unittest
 import urlparse
+
+import unittest2 as unittest
 
 import mitogen.master
 if mitogen.is_master:  # TODO: shouldn't be necessary.

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -7,7 +7,7 @@ import sys
 import time
 import urlparse
 
-import unittest2 as unittest
+import unittest2
 
 import mitogen.master
 if mitogen.is_master:  # TODO: shouldn't be necessary.
@@ -114,7 +114,7 @@ def wait_for_port(
                                  % (host, port))
 
 
-class TestCase(unittest.TestCase):
+class TestCase(unittest2.TestCase):
     def assertRaises(self, exc, func, *args, **kwargs):
         """Like regular assertRaises, except return the exception that was
         raised. Can't use context manager because tests must run on Python2.4"""

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -126,9 +126,6 @@ class TestCase(unittest.TestCase):
             assert 0, '%r raised %r, not %r' % (func, e, exc)
         assert 0, '%r did not raise %r' % (func, exc)
 
-    def assertContains(self, needle, hay):
-        assert needle in hay, "%r not found in %r" % (needle, hay)
-
 
 class DockerizedSshDaemon(object):
     def __init__(self):

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import unittest
+import unittest2 as unittest
 
 import mitogen.master
 import mitogen.utils

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -21,14 +21,14 @@ class RunWithRouterTest(unittest.TestCase):
 
     def test_run_with_broker(self):
         router = mitogen.utils.run_with_router(func0)
-        self.assertTrue(isinstance(router, mitogen.master.Router))
+        self.assertIsInstance(router, mitogen.master.Router)
         self.assertFalse(router.broker._thread.isAlive())
 
 
 class WithRouterTest(unittest.TestCase):
     def test_with_broker(self):
         router = func()
-        self.assertTrue(isinstance(router, mitogen.master.Router))
+        self.assertIsInstance(router, mitogen.master.Router)
         self.assertFalse(router.broker._thread.isAlive())
 
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import unittest2 as unittest
+import unittest2
 
 import mitogen.master
 import mitogen.utils
@@ -15,7 +15,7 @@ def func(router):
     return router
 
 
-class RunWithRouterTest(unittest.TestCase):
+class RunWithRouterTest(unittest2.TestCase):
     # test_shutdown_on_exception
     # test_shutdown_on_success
 
@@ -25,7 +25,7 @@ class RunWithRouterTest(unittest.TestCase):
         self.assertFalse(router.broker._thread.isAlive())
 
 
-class WithRouterTest(unittest.TestCase):
+class WithRouterTest(unittest2.TestCase):
     def test_with_broker(self):
         router = func()
         self.assertIsInstance(router, mitogen.master.Router)
@@ -33,4 +33,4 @@ class WithRouterTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest2.main()


### PR DESCRIPTION
This doesn't fix any tests or add any new ones, but it does make the test output more useful for failures.

### Before
```
FAIL: test_ansible_six_messed_up_path (__main__.BrokenModulesTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/responder_test.py", line 77, in test_ansible_six_messed_up_path
    self.assertTrue(isinstance(msg.unpickle(), tuple))
AssertionError: False is not true
```

### After
```
FAIL: test_ansible_six_messed_up_path (__main__.BrokenModulesTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/responder_test.py", line 78, in test_ansible_six_messed_up_path
    self.assertIsInstance(msg.unpickle(), tuple)
AssertionError: None is not an instance of <type 'tuple'>
```

Fixes #64