### PR TITLE
Replace all calls to file() with open()

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -363,7 +363,7 @@ a large fleet of machines, or to alert the parent of unexpected state changes.
             elif new_size < size:
                 size = 0
 
-            fp = file(path, 'r')
+            fp = open(path, 'r')
             fp.seek(size)
             channel.send(fp.read(new_size - size))
             fp.close()

--- a/mitogen/ansible/helpers.py
+++ b/mitogen/ansible/helpers.py
@@ -21,7 +21,7 @@ def exec_command(cmd, in_data=None):
 
 
 def read_path(path):
-    return file(path, 'rb').read()
+    return open(path, 'rb').read()
 
 
 def write_path(path, s):

--- a/mitogen/core.py
+++ b/mitogen/core.py
@@ -1127,7 +1127,7 @@ class ExternalContext(object):
         # Reopen with line buffering.
         sys.stdout = os.fdopen(1, 'w', 1)
 
-        fp = file('/dev/null')
+        fp = open('/dev/null')
         try:
             os.dup2(fp.fileno(), 0)
         finally:

--- a/mitogen/fakessh.py
+++ b/mitogen/fakessh.py
@@ -309,7 +309,7 @@ def run(dest, router, args, deadline=None, econtext=None):
     tmp_path = tempfile.mkdtemp(prefix='mitogen_fakessh')
     try:
         ssh_path = os.path.join(tmp_path, 'ssh')
-        fp = file(ssh_path, 'w')
+        fp = open(ssh_path, 'w')
         try:
             fp.write('#!%s\n' % (sys.executable,))
             fp.write(inspect.getsource(mitogen.core))

--- a/tests/data/plain_old_module.py
+++ b/tests/data/plain_old_module.py
@@ -8,7 +8,7 @@ import math
 
 def get_sentinel_value():
     # Some proof we're even talking to the mitogen-test Docker image
-    return file('/etc/sentinel').read()
+    return open('/etc/sentinel').read()
 
 
 def add(x, y):

--- a/tests/first_stage_test.py
+++ b/tests/first_stage_test.py
@@ -26,7 +26,7 @@ class CommandLineTest(testlib.RouterMixin, testlib.TestCase):
         # from the pipe, which is a valid script, and therefore exit indicating
         # success.
 
-        fp = file("/dev/null", "r")
+        fp = open("/dev/null", "r")
         proc = subprocess.Popen(args,
             stdin=fp,
             stdout=subprocess.PIPE,

--- a/tests/module_finder_test.py
+++ b/tests/module_finder_test.py
@@ -89,7 +89,7 @@ class GetModuleViaSysModulesTest(testlib.TestCase):
         import __main__
         path, src, is_pkg = self.call('__main__')
         self.assertEquals(path, __main__.__file__)
-        self.assertEquals(src, file(path).read())
+        self.assertEquals(src, open(path).read())
         self.assertFalse(is_pkg)
 
     def test_dylib_fails(self):


### PR DESCRIPTION
Although these are synonyms in Python 2.x, when using MyPy to typecheck
code use of file() causes spurious errors.

This commit also serves as one small step to Python 3.x compatibility,
since 3.x removes the file() builtin.