### PR TITLE
Fix TypeError while initiliazing ImporterMixin

### DIFF
--- a/tests/importer_test.py
+++ b/tests/importer_test.py
@@ -18,7 +18,7 @@ class ImporterMixin(testlib.RouterMixin):
     def setUp(self):
         super(ImporterMixin, self).setUp()
         self.context = mock.Mock()
-        self.importer = mitogen.core.Importer(self.context, '')
+        self.importer = mitogen.core.Importer(self.router, self.context, '')
 
     def tearDown(self):
         sys.modules.pop(self.modname, None)


### PR DESCRIPTION
Since f44356af3275912f7df78fa58e860f107a71e7e5 mitogen.core.Importer()
takes a Router instance.