### PR TITLE
Use Python 2.4 compatible module import

### DIFF
--- a/mitogen/__init__.py
+++ b/mitogen/__init__.py
@@ -99,7 +99,7 @@ def main(log_level='INFO'):
     def wrapper(func):
         if func.__module__ != '__main__':
             return func
-        from . import utils
+        from mitogen import utils
         utils.log_to_file(level=log_level)
         return utils.run_with_router(func)
     return wrapper


### PR DESCRIPTION
Python 2.4 does not support explicit relative imports. They were added
at Python 2.5, along with `from __future__ import absolute_import`.

On 2.x this will mean the import is first (implicitly) tried relative,
but on 3.x it will always be tried absolute.

Fixes #92