### PR TITLE
Address lgtm.com warnings

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,3 @@
+path_classifiers:
+  thirdparty:
+    - "mitogen/compat/*.py"

--- a/mitogen/core.py
+++ b/mitogen/core.py
@@ -121,8 +121,14 @@ class TimeoutError(Error):
 
 
 class Dead(object):
+    def __hash__(self):
+        return hash(Dead)
+
     def __eq__(self, other):
         return type(other) is Dead
+
+    def __ne__(self, other):
+        return type(other) is not Dead
 
     def __reduce__(self):
         return (_unpickle_dead, ())

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -519,7 +519,14 @@ class ModuleForwarder(object):
         tup = self.importer._cache[fullname]
         if tup is not None:
             for related in tup[4]:
-                rtup = self.importer._cache[fullname]
+                LOG.debug('%r._on_get_module(): trying related %r',
+                          self, related)
+                try:
+                    rtup = self.importer._cache[related]
+                except KeyError:
+                    LOG.warn('%r._on_get_module(): skipping %r, not in cache', 
+                             self, related)
+                    continue
                 self._send_one_module(msg, rtup)
 
         self._send_one_module(msg, tup)

--- a/mitogen/ssh.py
+++ b/mitogen/ssh.py
@@ -126,5 +126,4 @@ class Stream(mitogen.parent.Stream):
                 LOG.debug('sending password')
                 self.transmit_side.write(self.password + '\n')
                 password_sent = True
-        else:
-            raise mitogen.core.StreamError('bootstrap failed')
+        raise mitogen.core.StreamError('bootstrap failed')

--- a/mitogen/sudo.py
+++ b/mitogen/sudo.py
@@ -107,5 +107,4 @@ class Stream(mitogen.parent.Stream):
                 LOG.debug('sending password')
                 os.write(self.transmit_side.fd, self.password + '\n')
                 password_sent = True
-        else:
-            raise mitogen.core.StreamError('bootstrap failed')
+        raise mitogen.core.StreamError('bootstrap failed')


### PR DESCRIPTION
lgtm.com is a static analysis service that identifies coding patterns likely to be mistakes, or sources of confusion. During PyConUK 2017 I added the Mitogen repository. The current list of alerts is https://lgtm.com/projects/g/dw/mitogen/alerts/?mode=list. This PR should address 7 of the (currently) 10 alerts.

Unfortunately the service only scans non-fork projects, and to my knowledge only the default branch. So we won't see the result until after this is merged.

Refs #61 