### PR TITLE
Code golf some bytes from first stage and preamble stage

### DIFF
--- a/mitogen/core.py
+++ b/mitogen/core.py
@@ -445,7 +445,7 @@ class Importer(object):
                 'mitogen.core',
                 None,
                 'mitogen/core.py',
-                zlib.compress(core_src),
+                zlib.compress(core_src, 9),
                 [],
             )
 

--- a/mitogen/master.py
+++ b/mitogen/master.py
@@ -521,7 +521,7 @@ class ModuleResponder(object):
 
         if fullname == '__main__':
             source = self.neutralize_main(source)
-        compressed = zlib.compress(source)
+        compressed = zlib.compress(source, 9)
         related = list(self._finder.find_related(fullname))
         # 0:fullname 1:pkg_present 2:path 3:compressed 4:related
         tup = fullname, pkg_present, path, compressed, related

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -321,7 +321,10 @@ class Stream(mitogen.core.Stream):
             os.dup2(0,100)
             os.dup2(R,0)
             os.dup2(r,101)
-            for f in R,r,W,w:os.close(f)
+            os.close(R)
+            os.close(r)
+            os.close(W)
+            os.close(w)
             os.environ['ARGV0']=e=sys.executable
             os.execv(e,['mitogen:CONTEXT_NAME'])
         os.write(1,'EC0\n')

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -317,7 +317,6 @@ class Stream(mitogen.core.Stream):
     # Optimized for minimum byte count after minification & compression.
     @staticmethod
     def _first_stage():
-        import os,sys
         R,W=os.pipe()
         r,w=os.pipe()
         if os.fork():
@@ -352,7 +351,7 @@ class Stream(mitogen.core.Stream):
         # same str (2.x) or an equivalent bytes (3.x).
         return [
             self.python_path, '-c',
-            'import codecs;_=codecs.decode;'
+            'import codecs,os,sys;_=codecs.decode;'
             'exec(_(_("%s".encode(),"base64"),"zip"))' % (encoded,)
         ]
 

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -331,7 +331,7 @@ class Stream(mitogen.core.Stream):
             os.environ['ARGV0']=e=sys.executable
             os.execv(e,['mitogen:CONTEXT_NAME'])
         os.write(1,'EC0\n')
-        C=_(sys.stdin.read(PREAMBLE_COMPRESSED_LEN), 'zlib')
+        C=_(sys.stdin.read(PREAMBLE_COMPRESSED_LEN), 'zip')
         os.fdopen(W,'w',0).write(C)
         os.fdopen(w,'w',0).write('PREAMBLE_LEN\n'+C)
         os.write(1,'EC1\n')
@@ -353,7 +353,7 @@ class Stream(mitogen.core.Stream):
         return [
             self.python_path, '-c',
             'import codecs;_=codecs.decode;'
-            'exec(_(_("%s".encode(),"base64"),"zlib"))' % (encoded,)
+            'exec(_(_("%s".encode(),"base64"),"zip"))' % (encoded,)
         ]
 
     def get_preamble(self):

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -336,7 +336,7 @@ class Stream(mitogen.core.Stream):
         source = textwrap.dedent('\n'.join(source.strip().split('\n')[2:]))
         source = source.replace('    ', '\t')
         source = source.replace('CONTEXT_NAME', self.remote_name)
-        encoded = source.encode('zlib').encode('base64').replace('\n', '')
+        encoded = zlib.compress(source, 9).encode('base64').replace('\n', '')
         # We can't use bytes.decode() in 3.x since it was restricted to always
         # return unicode, so codecs.decode() is used instead. In 3.x
         # codecs.decode() requires a bytes object. Since we must be compatible
@@ -363,7 +363,7 @@ class Stream(mitogen.core.Stream):
             'blacklist': self._router.get_module_blacklist(),
         },)
 
-        compressed = zlib.compress(minimize_source(source))
+        compressed = zlib.compress(minimize_source(source), 9)
         return str(len(compressed)) + '\n' + compressed
 
     create_child = staticmethod(create_child)

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -327,10 +327,10 @@ class Stream(mitogen.core.Stream):
             os.close(r)
             os.close(W)
             os.close(w)
-            os.environ['ARGV0']=e=sys.executable
-            os.execv(e,['mitogen:CONTEXT_NAME'])
+            os.environ['ARGV0']=sys.executable
+            os.execv(sys.executable,['mitogen:CONTEXT_NAME'])
         os.write(1,'EC0\n')
-        C=_(sys.stdin.read(PREAMBLE_COMPRESSED_LEN), 'zip')
+        C=_(sys.stdin.read(PREAMBLE_COMPRESSED_LEN),'zip')
         os.fdopen(W,'w',0).write(C)
         os.fdopen(w,'w',0).write('PREAMBLE_LEN\n'+C)
         os.write(1,'EC1\n')

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -330,7 +330,7 @@ class Stream(mitogen.core.Stream):
             os.environ['ARGV0']=sys.executable
             os.execl(sys.executable,'mitogen:CONTEXT_NAME')
         os.write(1,'EC0\n')
-        C=_(sys.stdin.read(PREAMBLE_COMPRESSED_LEN),'zip')
+        C=_(os.fdopen(0,'rb').read(PREAMBLE_COMPRESSED_LEN),'zip')
         os.fdopen(W,'w',0).write(C)
         os.fdopen(w,'w',0).write('PREAMBLE_LEN\n'+C)
         os.write(1,'EC1\n')

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -344,7 +344,7 @@ class Stream(mitogen.core.Stream):
         # same str (2.x) or an equivalent bytes (3.x).
         return [
             self.python_path, '-c',
-            'from codecs import decode as _;'
+            'import codecs;_=codecs.decode;'
             'exec(_(_("%s".encode(),"base64"),"zlib"))' % (encoded,)
         ]
 

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -309,9 +309,12 @@ class Stream(mitogen.core.Stream):
             )
         )
 
-    # base64'd and passed to 'python -c'. It forks, dups 0->100, creates a
-    # pipe, then execs a new interpreter with a custom argv. 'CONTEXT_NAME' is
-    # replaced with the context name. Optimized for size.
+    # Minimised, gzipped, base64'd and passed to 'python -c'. It forks, dups
+    # file descriptor 0 as 100, creates a pipe, then execs a new interpreter
+    # with a custom argv.
+    # 'CONTEXT_NAME', 'PREAMBLE_COMPRESSED_LEN', and 'PREAMBLE_LEN' are
+    # substituted with their respective values.
+    # Optimized for minimum byte count after minification & compression.
     @staticmethod
     def _first_stage():
         import os,sys
@@ -328,9 +331,9 @@ class Stream(mitogen.core.Stream):
             os.environ['ARGV0']=e=sys.executable
             os.execv(e,['mitogen:CONTEXT_NAME'])
         os.write(1,'EC0\n')
-        C=_(sys.stdin.read(input()), 'zlib')
+        C=_(sys.stdin.read(PREAMBLE_COMPRESSED_LEN), 'zlib')
         os.fdopen(W,'w',0).write(C)
-        os.fdopen(w,'w',0).write('%s\n'%len(C)+C)
+        os.fdopen(w,'w',0).write('PREAMBLE_LEN\n'+C)
         os.write(1,'EC1\n')
 
     def get_boot_command(self):
@@ -338,6 +341,9 @@ class Stream(mitogen.core.Stream):
         source = textwrap.dedent('\n'.join(source.strip().split('\n')[2:]))
         source = source.replace('    ', '\t')
         source = source.replace('CONTEXT_NAME', self.remote_name)
+        preamble_compressed = self.get_preamble()
+        source = source.replace('PREAMBLE_COMPRESSED_LEN', str(len(preamble_compressed)))
+        source = source.replace('PREAMBLE_LEN', str(len(zlib.decompress(preamble_compressed))))
         encoded = zlib.compress(source, 9).encode('base64').replace('\n', '')
         # We can't use bytes.decode() in 3.x since it was restricted to always
         # return unicode, so codecs.decode() is used instead. In 3.x
@@ -365,8 +371,7 @@ class Stream(mitogen.core.Stream):
             'blacklist': self._router.get_module_blacklist(),
         },)
 
-        compressed = zlib.compress(minimize_source(source), 9)
-        return str(len(compressed)) + '\n' + compressed
+        return zlib.compress(minimize_source(source), 9)
 
     create_child = staticmethod(create_child)
 

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -332,7 +332,6 @@ class Stream(mitogen.core.Stream):
         os.fdopen(W,'w',0).write(C)
         os.fdopen(w,'w',0).write('%s\n'%len(C)+C)
         os.write(1,'EC1\n')
-        sys.exit(0)
 
     def get_boot_command(self):
         source = inspect.getsource(self._first_stage)

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -328,7 +328,7 @@ class Stream(mitogen.core.Stream):
             os.close(W)
             os.close(w)
             os.environ['ARGV0']=sys.executable
-            os.execv(sys.executable,['mitogen:CONTEXT_NAME'])
+            os.execl(sys.executable,'mitogen:CONTEXT_NAME')
         os.write(1,'EC0\n')
         C=_(sys.stdin.read(PREAMBLE_COMPRESSED_LEN),'zip')
         os.fdopen(W,'w',0).write(C)

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -314,7 +314,7 @@ class Stream(mitogen.core.Stream):
     # replaced with the context name. Optimized for size.
     @staticmethod
     def _first_stage():
-        import os,sys,zlib
+        import os,sys
         R,W=os.pipe()
         r,w=os.pipe()
         if os.fork():
@@ -328,7 +328,7 @@ class Stream(mitogen.core.Stream):
             os.environ['ARGV0']=e=sys.executable
             os.execv(e,['mitogen:CONTEXT_NAME'])
         os.write(1,'EC0\n')
-        C=zlib.decompress(sys.stdin.read(input()))
+        C=_(sys.stdin.read(input()), 'zlib')
         os.fdopen(W,'w',0).write(C)
         os.fdopen(w,'w',0).write('%s\n'%len(C)+C)
         os.write(1,'EC1\n')

--- a/tests/first_stage_test.py
+++ b/tests/first_stage_test.py
@@ -36,7 +36,7 @@ class CommandLineTest(testlib.RouterMixin, testlib.TestCase):
         stdout, stderr = proc.communicate()
         self.assertEquals(0, proc.returncode)
         self.assertEquals("EC0\n", stdout)
-        self.assertIn("EOFError", stderr)
+        self.assertIn("Error -5 while decompressing data: incomplete or truncated stream", stderr)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Taken together these commits reduce the first stage from 482 bytes to ~~448~~ 439 bytes, and the preamble from 8946 bytes to 8941 bytes. They eliminate use of `input()` in the first stage, for better Python 3.x compatibility. The use of 'zip' as an alias for the 'zlib' codecs breaks compatibility with Python 3.0 -> 3.3 though.

@dw I'm unsure i precomputing the compressed & uncompressed preamble sizes introduces any race conditions, e.g. could the length of the preamble change between `create_child()`/`get_boot_command()` and `_ec0_received()`?