### PR TITLE
tests: Fix no such option -o running FakeSsh.test_okay()

### DIFF
--- a/tests/data/fakessh.py
+++ b/tests/data/fakessh.py
@@ -7,6 +7,7 @@ import sys
 
 parser = optparse.OptionParser()
 parser.add_option('--user', '-l', action='store')
+parser.add_option('-o', dest='options', action='append')
 parser.disable_interspersed_args()
 
 opts, args = parser.parse_args(sys.argv[1:])


### PR DESCRIPTION
Full output of failed test

```
ERROR: test_okay (__main__.FakeSshTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/ssh_test.py", line 16, in test_okay
    ssh_path=testlib.data_path('fakessh.py'),
  File "/home/alex/src/mitogen/mitogen/master.py", line 650, in ssh
    return self.connect('ssh', **kwargs)
  File "/home/alex/src/mitogen/mitogen/parent.py", line 463, in connect
    return self._connect(context_id, klass, name=name, **kwargs)
  File "/home/alex/src/mitogen/mitogen/parent.py", line 449, in _connect
    stream.connect()
  File "/home/alex/src/mitogen/mitogen/ssh.py", line 104, in connect
    super(Stream, self).connect()
  File "/home/alex/src/mitogen/mitogen/parent.py", line 395, in connect
    self._connect_bootstrap()
  File "/home/alex/src/mitogen/mitogen/ssh.py", line 116, in
_connect_bootstrap
    time.time() + 10.0):
  File "/home/alex/src/mitogen/mitogen/parent.py", line 207, in
iter_read
    (''.join(bits)[-300:],)
mitogen.core.StreamError: EOF on stream; last 300 bytes received:
'Usage: fakessh.py [options]\n\nfakessh.py: error: no such option: -o\n'
```