### PR TITLE
tests: Add Tox config for Python 2.6 and 2.7

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,9 +1,15 @@
 -r docs/docs-requirements.txt
 ansible==2.3.1.0
-Django==1.11.5  # for module_finder_test
-docker==2.5.1
-docker[tls]==2.5.1
+Django==1.6.11; python_version < '2.7'
+Django==1.11.5; python_version >= '2.7' # for module_finder_test
+https://github.com/docker/docker-py/archive/1.10.6.tar.gz; python_version < '2.7'
+docker[tls]==2.5.1; python_version >= '2.7'
 mock==2.0.0
 pytest-catchlog==1.2.2
 pytest==3.1.2
+PyYAML==3.11; python_version < '2.7'
+PyYAML==3.12; python_version >= '2.7'
 unittest2==1.1.0
+# Fix InsecurePlatformWarning while creating py26 tox environment
+# https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
+urllib3[secure]; python_version < '2.7.9'

--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -1,3 +1,3 @@
 Sphinx==1.7.1
-sphinx-autobuild==0.7.1
+sphinx-autobuild==0.6.0 # Last version to support Python 2.6
 sphinxcontrib-programoutput==0.11

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
     name = 'mitogen',
@@ -35,12 +35,7 @@ setup(
     author = 'David Wilson',
     license = 'New BSD',
     url = 'https://github.com/dw/mitogen/',
-    packages = [
-        'mitogen',
-        'ansible_mitogen',
-        'ansible_mitogen.connection',
-        'ansible_mitogen.strategy',
-    ],
+    packages = find_packages(exclude=['tests', 'examples']),
     use_2to3=True,
     zip_safe = False,
     classifiers = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+envlist =
+    py26,
+    py27,
+
+[testenv]
+deps =
+    -r{toxinidir}/dev_requirements.txt
+
+commands =
+    {posargs:./test.sh}
+
+[testenv:docs]
+basepython = python
+changedir = docs
+commands =
+    sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html


### PR DESCRIPTION
I could not get Python 2.5 or earlier to work. Too many packages (critically docker) don't support it.

[pyenv](https://github.com/pyenv/pyenv) or it's plugin [python-build](https://github.com/pyenv/pyenv/tree/master/plugins/python-build) are the best ways I know to install different Python versions.