### PR TITLE
ansible: prevent Unicode strings leaking into sys.argv

### DIFF
--- a/ansible_mitogen/runner.py
+++ b/ansible_mitogen/runner.py
@@ -99,8 +99,8 @@ class Runner(object):
         if raw_params is not None:
             args['_raw_params'] = raw_params
 
-        self.module = module
-        self.remote_tmp = os.path.expanduser(remote_tmp)
+        self.module = utf8(module)
+        self.remote_tmp = utf8(os.path.expanduser(remote_tmp))
         self.service_context = service_context
         self.emulate_tty = emulate_tty
         self.raw_params = raw_params

--- a/tests/ansible/integration/runner/custom_python_new_style_module.yml
+++ b/tests/ansible/integration/runner/custom_python_new_style_module.yml
@@ -13,3 +13,12 @@
           (not out.results[0].changed) and
           out.results[0].input[0].ANSIBLE_MODULE_ARGS.foo and
           out.results[0].msg == 'Here is my input'
+
+
+    # Verify sys.argv is not Unicode.
+    - custom_python_detect_environment:
+      register: out
+
+    - assert:
+        that:
+          - out.argv_types == ["<type 'str'>"]

--- a/tests/ansible/lib/modules/custom_python_detect_environment.py
+++ b/tests/ansible/lib/modules/custom_python_detect_environment.py
@@ -14,6 +14,7 @@ def main():
     module = AnsibleModule(argument_spec={})
     module.exit_json(
         argv=sys.argv,
+        argv_types=[str(type(s)) for s in sys.argv],
         env=dict(os.environ),
         cwd=os.getcwd(),
         python_path=sys.path,


### PR DESCRIPTION
The module name comes from YAML via Jinja2.. it's always Unicode. Mixing
it into a temporary directory name produces a Unicode tempdir name,
which ends up in sys.argv via TemporaryArgv.