### PR TITLE
Move _DEAD into header, autogenerate dead messages

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -338,6 +338,12 @@ Message Class
 
     .. attribute:: data
 
+    .. attribute:: is_dead
+
+        :data:`True` if :attr:`reply_to` is set to the magic value
+        :data:`mitogen.core.IS_DEAD`, indicating the sender considers the
+        channel dead.
+
     .. py:method:: __init__ (\**kwargs)
 
         Construct a message from from the supplied `kwargs`. :py:attr:`src_id`
@@ -362,15 +368,18 @@ Message Class
         :raises mitogen.core.CallError:
             The serialized data contained CallError exception.
         :raises mitogen.core.ChannelError:
-            The serialized data contained :py:data:`mitogen.core._DEAD`.
+            The `is_dead` field was set.
 
-    .. method:: reply (obj, \**kwargs)
+    .. method:: reply (obj, router=None, \**kwargs)
 
-        Compose a pickled reply to this message and send it using
-        :py:attr:`router`.
+        Compose a reply to this message and send it using :py:attr:`router`, or
+        `router` is :py:attr:`router` is :data:`None`.
 
         :param obj:
-            Object to serialize.
+            Either a :class:`Message`, or an object to be serialized in order
+            to construct a new message.
+        :param router:
+            Optional router to use if :attr:`router` is :data:`None`.
         :param kwargs:
             Optional keyword parameters overriding message fields in the reply.
 
@@ -429,7 +438,7 @@ Router Class
 
         :param mitogen.core.Context respondent:
             Context that messages to this handle are expected to be sent from.
-            If specified, arranges for :py:data:`_DEAD` to be delivered to `fn`
+            If specified, arranges for a dead message to be delivered to `fn`
             when disconnection of the context is detected.
 
             In future `respondent` will likely also be used to prevent other
@@ -943,7 +952,7 @@ Receiver Class
 
     :param mitogen.core.Context respondent:
         Reference to the context this receiver is receiving from. If not
-        ``None``, arranges for the receiver to receive :py:data:`_DEAD` if
+        ``None``, arranges for the receiver to receive a dead message if
         messages can no longer be routed to the context, due to disconnection
         or exit.
 
@@ -1046,8 +1055,8 @@ Sender Class
 
     .. py:method:: close ()
 
-        Send :py:data:`_DEAD` to the remote end, causing
-        :py:meth:`ChannelError` to be raised in any waiting thread.
+        Send a dead message to the remote end, causing :py:meth:`ChannelError`
+        to be raised in any waiting thread.
 
     .. py:method:: send (data)
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -310,7 +310,6 @@ User-defined types may not be used, except for:
 * :py:class:`mitogen.core.CallError`
 * :py:class:`mitogen.core.Context`
 * :py:class:`mitogen.core.Sender`
-* :py:class:`mitogen.core._DEAD`
 
 Subclasses of built-in types must be undecorated using
 :py:func:`mitogen.utils.cast`.

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -400,14 +400,19 @@ Helper Functions
         disconnection was detected, otherwise ``False``.
 
 
-.. currentmodule:: mitogen.master
+.. currentmodule:: mitogen.parent
 
 .. autofunction:: create_child
 
 
-.. currentmodule:: mitogen.master
+.. currentmodule:: mitogen.parent
 
 .. autofunction:: tty_create_child
+
+
+.. currentmodule:: mitogen.parent
+
+.. autofunction:: hybrid_tty_create_child
 
 
 .. currentmodule:: mitogen.master

--- a/mitogen/fakessh.py
+++ b/mitogen/fakessh.py
@@ -134,20 +134,17 @@ class Process(object):
         self.control.put(('exit', status))
 
     def _on_stdin(self, msg):
-        if msg == mitogen.core._DEAD:
-            return
-
-        data = msg.unpickle(throw=False)
-        if data == mitogen.core._DEAD:
+        if msg.is_dead:
             IOLOG.debug('%r._on_stdin() -> %r', self, data)
             self.pump.close()
             return
 
+        data = msg.unpickle()
         IOLOG.debug('%r._on_stdin() -> len %d', self, len(data))
         self.pump.write(data)
 
     def _on_control(self, msg):
-        if msg != mitogen.core._DEAD:
+        if not msg.is_dead:
             command, arg = msg.unpickle(throw=False)
             LOG.debug('%r._on_control(%r, %s)', self, command, arg)
 

--- a/mitogen/master.py
+++ b/mitogen/master.py
@@ -295,7 +295,7 @@ class LogForwarder(object):
         )
 
     def _on_forward_log(self, msg):
-        if msg == mitogen.core._DEAD:
+        if msg.is_dead:
             return
 
         logger = self._cache.get(msg.src_id)
@@ -619,7 +619,7 @@ class ModuleResponder(object):
         stream.sent_modules.add(fullname)
 
     def _on_get_module(self, msg):
-        if msg == mitogen.core._DEAD:
+        if msg.is_dead:
             return
 
         LOG.debug('%r._on_get_module(%r)', self, msg.data)
@@ -742,7 +742,7 @@ class IdAllocator(object):
             self.lock.release()
 
     def on_allocate_id(self, msg):
-        if msg == mitogen.core._DEAD:
+        if msg.is_dead:
             return
 
         id_, last_id = self.allocate_block()

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -850,7 +850,7 @@ class RouteMonitor(object):
                 mitogen.core.fire(context, 'disconnect')
 
     def _on_add_route(self, msg):
-        if msg == mitogen.core._DEAD:
+        if msg.is_dead:
             return
 
         target_id_s, _, target_name = msg.data.partition(':')
@@ -870,7 +870,7 @@ class RouteMonitor(object):
         self.propagate(mitogen.core.ADD_ROUTE, target_id, target_name)
 
     def _on_del_route(self, msg):
-        if msg == mitogen.core._DEAD:
+        if msg.is_dead:
             return
 
         target_id = int(msg.data)
@@ -1055,7 +1055,7 @@ class ModuleForwarder(object):
 
     def _on_get_module(self, msg):
         LOG.debug('%r._on_get_module(%r)', self, msg)
-        if msg == mitogen.core._DEAD:
+        if msg.is_dead:
             return
 
         fullname = msg.data

--- a/mitogen/utils.py
+++ b/mitogen/utils.py
@@ -112,7 +112,6 @@ def cast(obj):
     if isinstance(obj, str):
         return str(obj)
     if isinstance(obj, (mitogen.core.Context,
-                        mitogen.core.Dead,
                         mitogen.core.CallError)):
         return obj
 

--- a/tests/call_function_test.py
+++ b/tests/call_function_test.py
@@ -25,10 +25,6 @@ def func_with_bad_return_value():
     return CrazyType()
 
 
-def func_returns_dead():
-    return mitogen.core._DEAD
-
-
 def func_accepts_returns_context(context):
     return context
 
@@ -68,9 +64,6 @@ class CallFunctionTest(testlib.RouterMixin, testlib.TestCase):
                 exc[0],
                 "cannot unpickle '%s'/'CrazyType'" % (__name__,),
         )
-
-    def test_returns_dead(self):
-        self.assertEqual(mitogen.core._DEAD, self.local.call(func_returns_dead))
 
     def test_aborted_on_local_context_disconnect(self):
         stream = self.router._stream_by_id[self.local.context_id]


### PR DESCRIPTION
This change blocks off 2 common scenarios where a race condition is
upgraded to a hang, when the library could internally do better.

* Since we don't know whether the receiver of a `reply_to` is expecting
  a raw or pickled message, and since in the case of a raw reply, there
  is no way to signal "dead" to the receiver, override the reply_to
  field to explicitly mark a message as dead using a special handle.

  This replaces the serialized _DEAD sentinel value with a slightly
  neater interface, in the form of the reserved IS_DEAD handle, and
  enables an important subsequent change: when a context cannot route a
  message, it can send a generic 'dead' reply back towards the message
  source, ensuring any sleeping thread is woken with ChannelError.

  The use of this field could potentially be extended later on if
  additional flags are needed, but for now this seems to suffice.

* Teach Router._invoke() to reply with a dead message when it receives a
  message for an invalid local handle.

* Teach Router._async_route() to reply with a dead message when it
  receives an unroutable message.