### PR TITLE
issue #179: ec0_receive() and connect_bootstrap() should use deadline.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: required
+addons:
+  apt:
+    update: true
 
 notifications:
   email: false

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -756,11 +756,10 @@ class Stream(mitogen.core.Stream):
     def _ec0_received(self):
         LOG.debug('%r._ec0_received()', self)
         write_all(self.transmit_side.fd, self.get_preamble())
-        discard_until(self.receive_side.fd, 'EC1\n', time.time() + 10.0)
+        discard_until(self.receive_side.fd, 'EC1\n', self.connect_deadline)
 
     def _connect_bootstrap(self, extra_fd):
-        deadline = time.time() + self.connect_timeout
-        discard_until(self.receive_side.fd, 'EC0\n', deadline)
+        discard_until(self.receive_side.fd, 'EC0\n', self.connect_deadline)
         self._ec0_received()
 
 


### PR DESCRIPTION
Now there is a single global deadline derived from ansible.cfg timeout=
value.