### PR TITLE
issue #179: don't reap first stage until core_src_fd is drained.

### DIFF
--- a/mitogen/core.py
+++ b/mitogen/core.py
@@ -1626,6 +1626,8 @@ class ExternalContext(object):
         listen(self.broker, 'exit', self._on_broker_exit)
 
         os.close(in_fd)
+
+    def _reap_first_stage(self):
         try:
             os.wait()  # Reap first stage.
         except OSError:
@@ -1746,6 +1748,7 @@ class ExternalContext(object):
             try:
                 self._setup_logging(debug, log_level)
                 self._setup_importer(importer, core_src_fd, whitelist, blacklist)
+                self._reap_first_stage()
                 if setup_package:
                     self._setup_package()
                 self._setup_globals(version, context_id, parent_ids)


### PR DESCRIPTION
Bootstrap would hang if (as of writing) a pipe sufficient to hold 42,006
bytes was not handed out by the kernel to the first stage. It was luck
that this didn't manifest before, as first stage could write the full
source and exit completely before reading begun.

It is not clear under which circumstances this could previously occur,
but at least since Linux 4.5, it can be triggered if
/proc/sys/fs/pipe-max-size is reduced from the default of 1MiB, which
can have the effect of capping the default pipe buffer size of 64KiB to
something lower.

Suspicion is that buffer pipe size could also be reduced under memory
pressure, as reference to busy machines appeared a few times in the bug
report.