### PR TITLE
core: race during Receiver construction.

### DIFF
--- a/mitogen/core.py
+++ b/mitogen/core.py
@@ -469,6 +469,7 @@ class Receiver(object):
                  respondent=None, policy=None):
         self.router = router
         self.handle = handle  # Avoid __repr__ crash in add_handler()
+        self._latch = Latch()  # Must exist prior to .add_handler()
         self.handle = router.add_handler(
             fn=self._on_receive,
             handle=handle,
@@ -476,7 +477,6 @@ class Receiver(object):
             persist=persist,
             respondent=respondent,
         )
-        self._latch = Latch()
 
     def __repr__(self):
         return 'Receiver(%r, %r)' % (self.router, self.handle)


### PR DESCRIPTION
It's possible for a message to arrive after .add_handler() but before
Latch construction.

This is papering over a bigger problem with service pool instantiation.

https://travis-ci.org/dw/mitogen/jobs/390409832#L2901

    TASK [Spin up a few interpreters] **********************************************
    changed: [target] => (item=1)
    ERROR! [pid 5355] 14:47:50.224945 E mitogen.ctx.ssh.localhost:2201.sudo.mitogen__user2: mitogen: Router(Broker(0x7f1e93911450))._invoke(Message(19100, 19095, 19095, 110, 1005, '\x80\x02U\x1fmitogen.service.PushFileServiceq\x01U\x11store_and_f'..8955)): <bound method Receiver._on_receive of Receiver(Router(Broker(0x7f1e93911450)), 110)> crashed
    Traceback (most recent call last):
      File "<stdin>", line 1471, in _invoke
      File "<stdin>", line 491, in _on_receive
    AttributeError: 'Receiver' object has no attribute '_latch'