### PR TITLE
issue #277: core: move Darwin versioner check into first stage

### DIFF
--- a/mitogen/ssh.py
+++ b/mitogen/ssh.py
@@ -91,7 +91,6 @@ class HostKeyError(mitogen.core.StreamError):
 class Stream(mitogen.parent.Stream):
     create_child = staticmethod(mitogen.parent.hybrid_tty_create_child)
     child_is_immediate_subprocess = False
-    python_path = 'python2.7'
 
     #: Number of -v invocations to pass on command line.
     ssh_debug_level = 0


### PR DESCRIPTION
The 'versioner.c' dodging check added in 0ef23d86 was wrong, since the
check occurred on the host machine, when the fix actually needs to apply
to the Darwin target.

Fixes ability to target OS X from a Red Hat controller, manifesting as
an error like:

    D mitogen: mitogen.parent.TtyLogStream('local.2472'):  'python(mitogen:dmw@localhost.localdomain:2449): realpath couldn\'t resolve "/usr/bin/python(mitogen:dmw@localhost.localdomain:2449)"'

The "realpath couldn't resolve" error comes from versioner.c:

    https://opensource.apple.com/source/perl/perl-104/versioner/versioner.c