### PR TITLE
Ansible 2.6 Testing Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,10 @@ matrix:
       env: MODE=debops_common VER=2.4.3.0
     # 2.5.5; 2.7 -> 2.7
     - python: "2.7"
-      env: MODE=debops_common VER=2.5.5
+      env: MODE=debops_common VER=2.6.1
     # 2.5.5; 3.6 -> 2.7
     - python: "3.6"
-      env: MODE=debops_common VER=2.5.5
+      env: MODE=debops_common VER=2.6.1
 
     # ansible_mitogen tests.
     # 2.4.3.0; Debian; 2.7 -> 2.7
@@ -59,22 +59,60 @@ matrix:
     # 2.5.5; Debian; 2.7 -> 2.7
     - python: "2.7"
       env: MODE=ansible VER=2.5.5 DISTRO=debian
-    # 2.5.5; CentOS; 2.7 -> 2.7
+    # 2.6.0; Debian; 2.7 -> 2.7
+    - python: "2.7"
+      env: MODE=ansible VER=2.6.0 DISTRO=debian
+    # 2.6.1; Debian; 2.7 -> 2.7
+    - python: "2.7"
+      env: MODE=ansible VER=2.6.1 DISTRO=debian
+
+   # Centos 7 Python2
+   # Latest
+    - python: "2.6"
+      env: MODE=ansible VER=2.6.1 DISTRO=centos7
+   # Backward Compatiability
     - python: "2.7"
       env: MODE=ansible VER=2.5.5 DISTRO=centos7
-    # 2.5.5; CentOS; 2.7 -> 2.6
     - python: "2.7"
-      env: MODE=ansible VER=2.5.5 DISTRO=centos6
-    # 2.5.5; CentOS; 2.6 -> 2.7
-    - python: "2.6"
+      env: MODE=ansible VER=2.6.0 DISTRO=centos7
+    - python: "2.7"
+      env: MODE=ansible VER=2.6.1 DISTRO=centos7
+
+    # Centos 7 Python3
+    - python: "3.6"
       env: MODE=ansible VER=2.5.5 DISTRO=centos7
-    # 2.5.5; CentOS; 2.6 -> 2.6
+    - python: "3.6"
+      env: MODE=ansible VER=2.6.0 DISTRO=centos7
+    - python: "3.6"
+      env: MODE=ansible VER=2.6.1 DISTRO=centos7
+
+
+    # Centos 6 Python2
+    # Latest
+    - python: "2.6"
+      env: MODE=ansible VER=2.6.1 DISTRO=centos6
+    # Backward Compatiability
     - python: "2.6"
       env: MODE=ansible VER=2.5.5 DISTRO=centos6
-    # 2.5.5; Debian; 3.6 -> 2.7
+    - python: "2.6"
+      env: MODE=ansible VER=2.6.0 DISTRO=centos6
+    - python: "2.7"
+      env: MODE=ansible VER=2.6.1 DISTRO=centos6
+
+    # Centos 6 Python3
     - python: "3.6"
       env: MODE=ansible VER=2.5.5 DISTRO=centos6
+    - python: "3.6"
+      env: MODE=ansible VER=2.6.0 DISTRO=centos6
+    - python: "3.6"
+      env: MODE=ansible VER=2.6.1 DISTRO=centos6
 
     # Sanity check our tests against vanilla Ansible, they should pass.
     - python: "2.7"
       env: MODE=ansible VER=2.5.5 DISTRO=debian STRATEGY=linear
+    - python: "2.7"
+      env: MODE=ansible VER=2.6.0 DISTRO=debian STRATEGY=linear
+    - python: "2.7"
+      env: MODE=ansible VER=2.6.1 DISTRO=debian STRATEGY=linear
+
+

--- a/.travis/ansible_tests.sh
+++ b/.travis/ansible_tests.sh
@@ -3,7 +3,7 @@
 
 TRAVIS_BUILD_DIR="${TRAVIS_BUILD_DIR:-`pwd`}"
 TMPDIR="/tmp/ansible-tests-$$"
-ANSIBLE_VERSION="${VER:-2.5.5}"
+ANSIBLE_VERSION="${VER:-2.6.1}"
 export ANSIBLE_STRATEGY="${STRATEGY:-mitogen_linear}"
 DISTRO="${DISTRO:-debian}"
 

--- a/.travis/debops_common_tests.sh
+++ b/.travis/debops_common_tests.sh
@@ -4,7 +4,7 @@
 TMPDIR="/tmp/debops-$$"
 TRAVIS_BUILD_DIR="${TRAVIS_BUILD_DIR:-`pwd`}"
 TARGET_COUNT="${TARGET_COUNT:-2}"
-ANSIBLE_VERSION="${VER:-2.5.5}"
+ANSIBLE_VERSION="${VER:-2.6.1}"
 DISTRO=debian  # Naturally DebOps only supports Debian.
 
 export PYTHONPATH="${PYTHONPATH}:${TRAVIS_BUILD_DIR}"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 
 # Mitogen
-
+<<<<<<< HEAD
+[![Build Status](https://travis-ci.org/dw/mitogen.png?branch=master)](https://travis-ci.org/{ORG-or-USERNAME}/{REPO-NAME})
+=======
+[![Build Status](https://travis-ci.org/{ORG-or-USERNAME}/{REPO-NAME}.png?branch=c%2B%2B11)](https://travis-ci.org/{ORG-or-USERNAME}/{REPO-NAME})
+>>>>>>> fcc10e644ee217743480940e4184a5bba1955487
 <a href="https://mitogen.readthedocs.io/">Please see the documentation</a>.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
 
 # Mitogen
-<<<<<<< HEAD
-[![Build Status](https://travis-ci.org/dw/mitogen.png?branch=master)](https://travis-ci.org/{ORG-or-USERNAME}/{REPO-NAME})
-=======
-[![Build Status](https://travis-ci.org/{ORG-or-USERNAME}/{REPO-NAME}.png?branch=c%2B%2B11)](https://travis-ci.org/{ORG-or-USERNAME}/{REPO-NAME})
->>>>>>> fcc10e644ee217743480940e4184a5bba1955487
+[![Build Status](https://travis-ci.org/dw/mitogen.png?branch=master)](https://travis-ci.org/dw/mitogen})
 <a href="https://mitogen.readthedocs.io/">Please see the documentation</a>.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 
 # Mitogen
-[![Build Status](https://travis-ci.org/dw/mitogen.png?branch=master)](https://travis-ci.org/dw/mitogen})
+<!-- [![Build Status](https://travis-ci.org/dw/mitogen.png?branch=master)](https://travis-ci.org/dw/mitogen}) -->
 <a href="https://mitogen.readthedocs.io/">Please see the documentation</a>.

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 -r docs/docs-requirements.txt
-ansible==2.5.5
+ansible==2.6.1
 coverage==4.5.1
 Django==1.6.11  # Last version supporting 2.6.
 mock==2.0.0

--- a/docs/ansible.rst
+++ b/docs/ansible.rst
@@ -58,7 +58,7 @@ Installation
 ------------
 
 1. Thoroughly review the :ref:`noteworthy_differences` and :ref:`changelog`.
-2. Verify Ansible 2.3-2.5 and Python 2.6, 2.7 or 3.6 are listed in ``ansible
+2. Verify Ansible 2.3-2.6.1 and Python 2.6, 2.7 or 3.6 are listed in ``ansible
    --version`` output.
 3. Download and extract |mitogen_url| from PyPI.
 4. Modify ``ansible.cfg``:
@@ -130,12 +130,12 @@ Noteworthy Differences
 * The ``doas``, ``su`` and ``sudo`` become methods are available. File bugs to
   register interest in more.
 
-* The `docker <https://docs.ansible.com/ansible/2.5/plugins/connection/docker.html>`_,
-  `jail <https://docs.ansible.com/ansible/2.5/plugins/connection/jail.html>`_,
-  `local <https://docs.ansible.com/ansible/2.5/plugins/connection/local.html>`_,
-  `lxc <https://docs.ansible.com/ansible/2.5/plugins/connection/lxc.html>`_,
-  `lxd <https://docs.ansible.com/ansible/2.5/plugins/connection/lxd.html>`_,
-  and `ssh <https://docs.ansible.com/ansible/2.5/plugins/connection/ssh.html>`_
+* The `docker <https://docs.ansible.com/ansible/2.6/plugins/connection/docker.html>`_,
+  `jail <https://docs.ansible.com/ansible/2.6/plugins/connection/jail.html>`_,
+  `local <https://docs.ansible.com/ansible/2.6/plugins/connection/local.html>`_,
+  `lxc <https://docs.ansible.com/ansible/2.6/plugins/connection/lxc.html>`_,
+  `lxd <https://docs.ansible.com/ansible/2.6/plugins/connection/lxd.html>`_,
+  and `ssh <https://docs.ansible.com/ansible/2.6/plugins/connection/ssh.html>`_
   built-in connection types are supported, along with Mitogen-specific
   :ref:`machinectl <machinectl>`, :ref:`mitogen_doas< mitogen_doas>`,
   :ref:`mitogen_su <su>`, :ref:`mitogen_sudo <sudo>`, and :ref:`setns <setns>`
@@ -507,7 +507,7 @@ Docker
 ~~~~~~
 
 Like `docker
-<https://docs.ansible.com/ansible/2.5/plugins/connection/docker.html>`_ except
+<https://docs.ansible.com/ansible/2.6/plugins/connection/docker.html>`_ except
 connection delegation is supported.
 
 * ``ansible_host``: Name of Docker container (default: inventory hostname).
@@ -534,7 +534,7 @@ FreeBSD Jail
 ~~~~~~~~~~~~
 
 Like `jail
-<https://docs.ansible.com/ansible/2.5/plugins/connection/jail.html>`_ except
+<https://docs.ansible.com/ansible/2.6/plugins/connection/jail.html>`_ except
 connection delegation is supported.
 
 * ``ansible_host``: Name of jail (default: inventory hostname).
@@ -545,7 +545,7 @@ Local
 ~~~~~
 
 Like `local
-<https://docs.ansible.com/ansible/2.5/plugins/connection/local.html>`_ except
+<https://docs.ansible.com/ansible/2.6/plugins/connection/local.html>`_ except
 connection delegation is supported.
 
 * ``ansible_python_interpreter``
@@ -556,8 +556,8 @@ connection delegation is supported.
 LXC
 ~~~
 
-Like `lxc <https://docs.ansible.com/ansible/2.5/plugins/connection/lxc.html>`_
-and `lxd <https://docs.ansible.com/ansible/2.5/plugins/connection/lxd.html>`_
+Like `lxc <https://docs.ansible.com/ansible/2.6/plugins/connection/lxc.html>`_
+and `lxd <https://docs.ansible.com/ansible/2.6/plugins/connection/lxd.html>`_
 except connection delegation is supported, and ``lxc-attach`` is always used
 rather than the LXC Python bindings, as is usual with ``lxc``.
 
@@ -646,7 +646,7 @@ When used as the ``mitogen_sudo`` connection method:
 SSH
 ~~~
 
-Like `ssh <https://docs.ansible.com/ansible/2.5/plugins/connection/ssh.html>`_
+Like `ssh <https://docs.ansible.com/ansible/2.6/plugins/connection/ssh.html>`_
 except connection delegation is supported.
 
 * ``ansible_ssh_timeout``


### PR DESCRIPTION
**Changes:**
-  Updated default travis config to use Ansible 2.6.1
- Added Ansible 2.6 and 2.6.1 to validation
- Sectioned out with comments distribution and python versions in travis config
- Added commented build status for future use in readme
- Updated ansible.rst to include updated links for Ansible 2.6

**Issues Resolved:**
closes #311  