### PR TITLE
format string: add missing argument

### DIFF
--- a/mitogen/master.py
+++ b/mitogen/master.py
@@ -371,7 +371,7 @@ class ModuleFinder(object):
             #        requests.packages.urllib3.contrib.pyopenssl"
             e = sys.exc_info()[1]
             LOG.debug('%r: loading %r using %r failed: %s',
-                      self, fullname, loader)
+                      self, fullname, loader, e)
             return
 
         if path is None or source is None:


### PR DESCRIPTION
Fix `TypeError: not enough arguments for format string` exception:

```
Traceback (most recent call last):
  File "mitogen/mitogen/master.py", line 640, in _send_module_and_related
    tup = self._build_tuple(fullname)
  File "mitogen/mitogen/master.py", line 603, in _build_tuple
    for name in self._finder.find_related(fullname)
  File "mitogen/mitogen/master.py", line 532, in find_related
    names = self.find_related_imports(name)
  File "mitogen/mitogen/master.py", line 483, in find_related_imports
    modpath, src, _ = self.get_module_source(fullname)
  File "mitogen/mitogen/master.py", line 434, in get_module_source
    tup = method(self, fullname)
  File "mitogen/mitogen/master.py", line 374, in _get_module_via_pkgutil
    self, fullname, loader)
  File "/usr/lib/python3.6/logging/__init__.py", line 1296, in debug
    self._log(DEBUG, msg, args, **kwargs)
  File "/usr/lib/python3.6/logging/__init__.py", line 1444, in _log
    self.handle(record)
  File "/usr/lib/python3.6/logging/__init__.py", line 1454, in handle
    self.callHandlers(record)
  File "/usr/lib/python3.6/logging/__init__.py", line 1516, in callHandlers
    hdlr.handle(record)
  File "/usr/lib/python3.6/logging/__init__.py", line 865, in handle
    self.emit(record)
  File "mitogen/ansible_mitogen/logging.py", line 68, in emit
    s = '[pid %d] %s' % (os.getpid(), self.format(record))
  File "/usr/lib/python3.6/logging/__init__.py", line 840, in format
    return fmt.format(record)
  File "/usr/lib/python3.6/logging/__init__.py", line 577, in format
    record.message = record.getMessage()
  File "/usr/lib/python3.6/logging/__init__.py", line 338, in getMessage
    msg = msg % self.args
TypeError: not enough arguments for format string
```

Example of log with this patch applied:
```
[pid 31296] 04:48:15.822232 D mitogen: ModuleFinder(): loading 'pkg_resources.extern.packaging' using <_frozen_importlib_external.SourceFileLoader object at 0x7fbc51c9aa58> failed: loader for pkg_resources._vendor.packaging cannot handle pkg_resources.extern.packaging
```