### PR TITLE
Use `lxc exec --mode=noninteractive` which is more widely compatible

### DIFF
--- a/mitogen/lxd.py
+++ b/mitogen/lxd.py
@@ -63,7 +63,7 @@ class Stream(mitogen.parent.Stream):
         bits = [
             self.lxc_path,
             'exec',
-            '--force-noninteractive',
+            '--mode=noninteractive',
             self.container,
             '--',
         ]

--- a/tests/lxd_test.py
+++ b/tests/lxd_test.py
@@ -18,7 +18,7 @@ class FakeLxcTest(testlib.RouterMixin, unittest2.TestCase):
         argv = eval(context.call(os.getenv, 'ORIGINAL_ARGV'))
         self.assertEquals(argv[0], lxc_path)
         self.assertEquals(argv[1], 'exec')
-        self.assertEquals(argv[2], '--force-noninteractive')
+        self.assertEquals(argv[2], '--mode=noninteractive')
         self.assertEquals(argv[3], 'container_name')
 
 


### PR DESCRIPTION
Closes #371