### PR TITLE
[Enhancement] handle kubectl vars from Ansible connector.

### DIFF
--- a/ansible_mitogen/connection.py
+++ b/ansible_mitogen/connection.py
@@ -132,11 +132,10 @@ def _connect_kubectl(spec):
     return {
         'method': 'kubectl',
         'kwargs': {
-            'username': spec['remote_user'],
             'pod': spec['remote_addr'],
-            #'container': spec['container'],
             'python_path': spec['python_path'],
             'connect_timeout': spec['ansible_ssh_timeout'] or spec['timeout'],
+            'additional_parameters': spec['additional_parameters'],
         }
     }
 
@@ -392,6 +391,8 @@ def config_from_play_context(transport, inventory_name, connection):
             connection.get_task_var('mitogen_machinectl_path'),
         'mitogen_ssh_debug_level':
             connection.get_task_var('mitogen_ssh_debug_level'),
+        'additional_parameters':
+            connection.get_additional_parameters(),
     }
 
 
@@ -570,6 +571,9 @@ class Connection(ansible.plugins.connection.ConnectionBase):
     @property
     def connected(self):
         return self.context is not None
+
+    def get_additional_parameters(self):
+        return []
 
     def _config_from_via(self, via_spec):
         """

--- a/ansible_mitogen/plugins/connection/mitogen_kubectl.py
+++ b/ansible_mitogen/plugins/connection/mitogen_kubectl.py
@@ -31,6 +31,8 @@ from __future__ import absolute_import
 import os.path
 import sys
 
+iteritems = getattr(dict, 'iteritems', dict.items)
+
 try:
     import ansible_mitogen
 except ImportError:
@@ -40,6 +42,15 @@ except ImportError:
 
 import ansible_mitogen.connection
 
+import ansible.plugins.connection.kubectl
 
 class Connection(ansible_mitogen.connection.Connection):
     transport = 'kubectl'
+
+    def get_additional_parameters(self):
+        parameters = []
+        for key, option in iteritems(ansible.plugins.connection.kubectl.CONNECTION_OPTIONS):
+            if self.get_task_var('ansible_' + key) is not None:
+                parameters += [ option, self.get_task_var('ansible_' + key) ]
+
+        return parameters

--- a/tests/ansible/test-kubectl.yml
+++ b/tests/ansible/test-kubectl.yml
@@ -1,8 +1,11 @@
 ---
 
 - name: "Create pod"
-  tags: always
+  tags: create
   hosts: localhost
+  vars:
+    pod_count: 10
+    loop_count: 5
   gather_facts: no
   tasks:
     - name: Create a test pod
@@ -19,7 +22,10 @@
             - name: python2
               image: python:2
               args: [ "sleep", "100000" ]
-      loop: "{{ range(10)|list }}"
+            - name: python3
+              image: python:3
+              args: [ "sleep", "100000" ]
+      loop: "{{ range(pod_count|int)|list }}"
 
     - name: "Wait pod to be running"
       debug: { msg: "pod is running" }
@@ -30,7 +36,7 @@
       delay: 2
       vars:
         pod_def: "{{lookup('k8s', kind='Pod', namespace='default', resource_name='test-pod-' ~ item)}}"
-      loop: "{{ range(10)|list }}"
+      loop: "{{ range(pod_count|int)|list }}"
 
     - name: "Add pod to pods group"
       add_host:
@@ -39,45 +45,95 @@
         ansible_connection: "kubectl"
       changed_when: no
       tags: "always"
-      loop: "{{ range(10)|list }}"
+      loop: "{{ range(pod_count|int)|list }}"
 
 - name: "Test kubectl connection (default strategy)"
   tags: default
   hosts: pods
   strategy: "linear"
+  vars:
+    pod_count: 10
+    loop_count: 5
   gather_facts: no
   tasks:
     - name: "Simple shell with linear"
       shell: ls /tmp
-      loop: [ 1, 2, 3, 4, 5 ]
+      loop: "{{ range(loop_count|int)|list }}"
 
     - name: "Simple file with linear"
       file:
         path: "/etc"
         state: directory
-      loop: [ 1, 2, 3, 4, 5 ]
+      loop: "{{ range(loop_count|int)|list }}"
+
+    - block:
+        - name: "Check python version on python3 container"
+          command: python --version
+          vars:
+            ansible_kubectl_container: python3
+          register: _
+
+        - assert: { that: "'Python 3' in _.stdout" }
+
+        - debug: var=_.stdout,_.stderr
+          run_once: yes
+
+        - name: "Check python version on default container"
+          command: python --version
+          register: _
+
+        - assert: { that: "'Python 2' in _.stderr" }
+
+        - debug: var=_.stdout,_.stderr
+          run_once: yes
 
 - name: "Test kubectl connection (mitogen strategy)"
   tags: mitogen
   hosts: pods
   strategy: "mitogen_linear"
+  vars:
+    pod_count: 10
+    loop_count: 5
   gather_facts: no
   tasks:
     - name: "Simple shell with mitogen"
       shell: ls /tmp
-      loop: [ 1, 2, 3, 4, 5 ]
+      loop: "{{ range(loop_count|int)|list }}"
 
     - name: "Simple file with mitogen"
       file:
         path: "/etc"
         state: directory
-      loop: [ 1, 2, 3, 4, 5 ]
-      register: _
+      loop: "{{ range(loop_count|int)|list }}"
+
+    - block:
+        - name: "Check python version on python3 container"
+          command: python --version
+          vars:
+            ansible_kubectl_container: python3
+          register: _
+
+        - assert: { that: "'Python 3' in _.stdout" }
+
+        - debug: var=_.stdout,_.stderr
+          run_once: yes
+
+        - name: "Check python version on default container"
+          command: python --version
+          register: _
+
+        - assert: { that: "'Python 2' in _.stderr" }
+
+        - debug: var=_.stdout,_.stderr
+          run_once: yes
+      tags: check
 
 - name: "Destroy pod"
   tags: cleanup
-  hosts: localhost
+  hosts: pods
   gather_facts: no
+  vars:
+    ansible_connection: "local"
   tasks:
     - name: Destroy pod
       k8s:
@@ -86,6 +142,5 @@
           apiVersion: v1
           kind: Pod
           metadata:
-            name: test-pod-{{item}}
+            name: "{{inventory_hostname}}"
             namespace: default
-      loop: "{{ range(10)|list }}"


### PR DESCRIPTION
This change allows the kubectl connector to support the same options as
Ansible's original connector.

The playbook sample comes with an example of a pod containing two containers
and checking that moving from one container to another, the version of Python
changes as expected.