### PR TITLE
Match "user@host: Permission denied ..." messages

### DIFF
--- a/mitogen/ssh.py
+++ b/mitogen/ssh.py
@@ -289,7 +289,11 @@ class Stream(mitogen.parent.Stream):
                 self._host_key_prompt()
             elif HOSTKEY_FAIL in buf.lower():
                 raise HostKeyError(self.hostkey_failed_msg)
-            elif buf.lower().startswith(PERMDENIED_PROMPT):
+            elif buf.lower().startswith((
+                    PERMDENIED_PROMPT,
+                    b("%s@%s: %s" % (self.username, self.hostname,
+                                     PERMDENIED_PROMPT)),
+                )):
                 # issue #271: work around conflict with user shell reporting
                 # 'permission denied' e.g. during chdir($HOME) by only matching
                 # it at the start of the line.


### PR DESCRIPTION
OpenSSH 7.5 changed the text of the permission denied message. As a
result ssh_test.SshTest.test_password_required and test_pubkey_required
were failing on an Ubuntu 18.04 client, which ships OpenSSH 7.6.

Refs
- https://bugzilla.mindrot.org/show_bug.cgi?id=2720