### PR TITLE
Add mitogen_host variable as optional target

### DIFF
--- a/ansible_mitogen/transport_config.py
+++ b/ansible_mitogen/transport_config.py
@@ -299,7 +299,10 @@ class PlayContextSpec(Spec):
         return self._inventory_name
 
     def remote_addr(self):
-        return self._play_context.remote_addr
+        return (
+            self._connection.get_task_var('mitogen_host') or
+            self._play_context.remote_addr
+        )
 
     def remote_user(self):
         return self._play_context.remote_user
@@ -437,6 +440,7 @@ class MitogenViaSpec(Spec):
 
     def remote_addr(self):
         return (
+            self._host_vars.get('mitogen_host') or
             self._host_vars.get('ansible_host') or
             self._inventory_name
         )

--- a/docs/ansible.rst
+++ b/docs/ansible.rst
@@ -702,7 +702,7 @@ Like `docker
 <https://docs.ansible.com/ansible/2.6/plugins/connection/docker.html>`_ except
 connection delegation is supported.
 
-* ``ansible_host``: Name of Docker container (default: inventory hostname).
+* ``mitogen_host``: Name of Docker container (default: ansible_host, inventory hostname).
 * ``ansible_user``: Name of user within the container to execute as.
 
 
@@ -715,7 +715,7 @@ Like `jail
 <https://docs.ansible.com/ansible/2.6/plugins/connection/jail.html>`_ except
 connection delegation is supported.
 
-* ``ansible_host``: Name of jail (default: inventory hostname).
+* ``mitogen_host``: Name of jail (default: ansible_host, inventory hostname).
 * ``ansible_user``: Name of user within the jail to execute as.
 
 
@@ -728,7 +728,7 @@ Like `kubectl
 <https://docs.ansible.com/ansible/2.6/plugins/connection/kubectl.html>`_ except
 connection delegation is supported.
 
-* ``ansible_host``: Name of pod (default: inventory hostname).
+* ``mitogen_host``: Name of pod (default: ansible_host, inventory hostname).
 * ``ansible_user``: Name of user to authenticate to API as.
 
 
@@ -770,7 +770,7 @@ connection delegation is supported, and ``lxc-attach`` is always used rather
 than the LXC Python bindings, as is usual with ``lxc``.
 
 * ``ansible_python_interpreter``
-* ``ansible_host``: Name of LXC container (default: inventory hostname).
+* ``mitogen_host``: Name of LXC container (default: ansible_host, inventory hostname).
 * ``mitogen_lxc_attach_path``: path to ``lxc-attach`` command if not available
     on the system path.
 
@@ -786,7 +786,7 @@ connection delegation is supported. The ``lxc`` command must be available on
 the host machine.
 
 * ``ansible_python_interpreter``
-* ``ansible_host``: Name of LXC container (default: inventory hostname).
+* ``mitogen_host``: Name of LXC container (default: ansible_host, inventory hostname).
 * ``mitogen_lxc_path``: path to ``lxc`` command if not available on the system
   path.
 
@@ -801,7 +801,7 @@ Like the `machinectl third party plugin
 connection delegation is supported. This is a light wrapper around the
 :ref:`setns <setns>` method.
 
-* ``ansible_host``: Name of Docker container (default: inventory hostname).
+* ``mitogen_host``: Name of Docker container (default: ansible_host, inventory hostname).
 * ``ansible_user``: Name of user within the container to execute as.
 * ``mitogen_machinectl_path``: path to ``machinectl`` command if not available
   as ``/bin/machinectl``.
@@ -822,8 +822,8 @@ A utility program must be installed to discover the PID of the container's root
 process.
 
 * ``mitogen_kind``: one of ``docker``, ``lxc``, ``lxd`` or ``machinectl``.
-* ``ansible_host``: Name of container as it is known to the corresponding tool
-  (default: inventory hostname).
+* ``mitogen_host``: Name of container as it is known to the corresponding tool
+  (default: ansible_host, inventory hostname).
 * ``ansible_user``: Name of user within the container to execute as.
 * ``mitogen_docker_path``: path to Docker if not available on the system path.
 * ``mitogen_lxc_path``: path to LXD's ``lxc`` command if not available as
@@ -892,7 +892,7 @@ Like `ssh <https://docs.ansible.com/ansible/2.6/plugins/connection/ssh.html>`_
 except connection delegation is supported.
 
 * ``ansible_ssh_timeout``
-* ``ansible_host``, ``ansible_ssh_host``
+* ``mitogen_host``, ``ansible_host``, ``ansible_ssh_host``
 * ``ansible_user``, ``ansible_ssh_user``
 * ``ansible_port``, ``ssh_port``
 * ``ansible_ssh_executable``, ``ssh_executable``
@@ -1146,7 +1146,7 @@ on each process whose name begins with ``mitogen:``::
     [pid 29858] futex(0x55ea9be52f60, FUTEX_WAIT_BITSET_PRIVATE|FUTEX_CLOCK_REALTIME, 0, NULL, 0xffffffff
     ^C
 
-    $ 
+    $
 
 This shows one thread waiting on IO (``poll``) and two more waiting on the same
 lock. It is taken from a real example of a deadlock due to a forking bug.

--- a/tests/ansible/hosts/osa-containers
+++ b/tests/ansible/hosts/osa-containers
@@ -4,6 +4,6 @@
 osa-host-machine ansible_host=172.29.236.100
 
 [osa-all-containers]
-osa-container-1 container_tech=lxc
-osa-container-2 container_tech=lxc
-osa-container-3 container_tech=lxc
+osa-container-1 ansible_host=10.0.0.1 mitogen_host=osa-container-1 container_tech=lxc
+osa-container-2 ansible_host=10.0.0.2 mitogen_host=osa-container-2 container_tech=lxc
+osa-container-3 ansible_host=10.0.0.3 mitogen_host=osa-container-3 container_tech=lxc


### PR DESCRIPTION
The option `mitogen_host` has been added allowing users to define it as
a given target which is useful in inventories where the `ansible_host`
is already defined and may be an IP address.

> This option was added to cater for the situation where containers are
  in a givne ansible inventory but are also assigned an IP address. The
  `mitogen_host` option can now be used to point mitogen at a given
  container instead of assuming `ansible_host` is the name of the
  container. This was developed with OpenStack-Ansible in mind and has
  been validated using LXC and nspawn containers which have multiple
  IP addresses.

Documentation has been updated to show how `mitogen_host` is used and
will fall back to the default: `ansible_host` and `inventory_hostname`.

osa-containers test inventory has been updated to reflect the new
option and how it is used.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>


Thanks for creating a PR! Here's a quick checklist to pay attention to:

* Please add an entry to docs/changelog.rst as appropriate.
done.

* Has some new parameter been added or semantics modified somehow? Please
  ensure relevant documentation is updated in docs/ansible.rst and
  docs/api.rst.
updated docs/ansible.rst

* If it's for new functionality, is there at least a basic test in either
  tests/ or tests/ansible/ covering it?
Updated tests/ansible/hosts/osa-containers though no additional tests have been added

* If it's for a new connection method, please try to stub out the
  implementation as in tests/data/stubs/, so that construction can be tested
  without having a working configuration.
n/a