### PR TITLE
Py36 deprecationwarning

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -435,6 +435,9 @@ Core Library
   meant an extra roundtrip and ~20KiB of data was wasted for any context that
   imported :mod:`mitogen.parent`.
 
+* `#523 <https://github.com/dw/mitogen/issues/523>` : the test suite didn't
+  generate a code coverage report if any test failed.
+
 
 Thanks!
 ~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -438,6 +438,9 @@ Core Library
 * `#523 <https://github.com/dw/mitogen/issues/523>` : the test suite didn't
   generate a code coverage report if any test failed.
 
+* `#524 <https://github.com/dw/mitogen/issues/524>` : Python 3.6+ emitted a
+  :class:`DeprecationWarning` for :func:`mitogen.utils.run_with_router`.
+
 
 Thanks!
 ~~~~~~~

--- a/mitogen/utils.py
+++ b/mitogen/utils.py
@@ -143,7 +143,7 @@ def log_to_file(path=None, io=False, level='INFO'):
 
 def run_with_router(func, *args, **kwargs):
     """
-    Arrange for `func(router, \*args, \**kwargs)` to run with a temporary
+    Arrange for `func(router, *args, **kwargs)` to run with a temporary
     :class:`mitogen.master.Router`, ensuring the Router and Broker are
     correctly shut down during normal or exceptional return.
 

--- a/run_tests
+++ b/run_tests
@@ -1,11 +1,27 @@
 #!/usr/bin/env bash
 
+# From https://unix.stackexchange.com/a/432145
+# Return the maximum of one or more integer arguments
+max() {
+    local max number
+
+    max="$1"
+
+    for number in "${@:2}"; do
+        if ((number > max)); then
+        max="$number"
+        fi
+    done
+
+    printf '%d\n' "$max"
+}
+
 echo '----- ulimits -----'
 ulimit -a
 echo '-------------------'
 echo
 
-set -o errexit
+# Don't use errexit, so coverage report is still generated when tests fail
 set -o pipefail
 
 if [ ! "$UNIT2" ]; then
@@ -27,6 +43,7 @@ fi
             --pattern '*_test.py' \
             "$@"
     fi
+    MITOGEN_TEST_STATUS=$?
 }
 
 # Second run appends. This is since 'discover' treats subdirs as packages and
@@ -47,7 +64,11 @@ fi
             --pattern '*_test.py' \
             "$@"
     fi
+    ANSIBLE_TEST_STATUS=$?
 }
 
 [ "$NOCOVERAGE" ] || coverage html
 [ "$NOCOVERAGE" ] || echo coverage report is at "file://$(pwd)/htmlcov/index.html"
+
+# Exit with a non-zero status if any test run did so
+exit "$(max $MITOGEN_TEST_STATUS $ANSIBLE_TEST_STATUS)"


### PR DESCRIPTION
`set -o errexit` was exiting run_tests prematurely if any test failed,
so the coverage report was not always generated.

Fixes #524 