### PR TITLE
Adds more dynamic installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,23 @@
 <!-- [![Build Status](https://travis-ci.org/dw/mitogen.png?branch=master)](https://travis-ci.org/dw/mitogen}) -->
 <a href="https://mitogen.networkgenomics.com/">Please see the documentation</a>.
 
-![](https://i.imgur.com/eBM6LhJ.gif)
+![screencast](https://i.imgur.com/eBM6LhJ.gif)
 
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/dw/mitogen.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/dw/mitogen/alerts/)
 
 [![Build Status](https://travis-ci.org/dw/mitogen.svg?branch=master)](https://travis-ci.org/dw/mitogen)
 
 [![Pipelines Status](https://dev.azure.com/dw-mitogen/Mitogen/_apis/build/status/dw.mitogen?branchName=master)](https://dev.azure.com/dw-mitogen/Mitogen/_build/latest?definitionId=1?branchName=master)
+
+## Installing mitogen
+
+This can be used to install or upgrade mitogen.  You can add the next two
+lines to your shell profile to make it more permanent. If you want to enable
+it only for a specific directory, you may want to check
+[direnv](https://direnv.net/).
+
+```bash
+pip install -U mitogen
+export ANSIBLE_STRATEGY_PLUGINS=$(mitogen -p)
+export ANSIBLE_STRATEGY=mitogen_linear
+```

--- a/mitogen/__main__.py
+++ b/mitogen/__main__.py
@@ -1,0 +1,30 @@
+import click
+import ansible_mitogen
+import os
+import sys
+
+
+@click.pass_context
+def all_procedure(ctx, dry_run, prepare):
+    if (dry_run is False) and (prepare is False):
+        print_help(ctx, None, value=True)
+
+@click.command()
+@click.version_option()
+@click.option("--path", "-p", is_flag=True, default=False, help="Return path to add to Ansible")
+@click.pass_context
+def main(ctx, path):
+
+    if not path:
+        click.echo(ctx.get_help())
+    else:
+        p = os.path.abspath(
+            os.path.join(
+            os.path.dirname(ansible_mitogen.__file__),
+            "plugins", "strategy"))
+
+        print(p)
+
+if __name__ == "__main__":
+
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,10 @@ source =
 omit =
     mitogen/compat/*
 
+[options.entry_points]
+console_scripts =
+    mitogen=mitogen.__main__:main
+
 [flake8]
 ignore = E402,E128,W503,E731
 exclude = mitogen/compat


### PR DESCRIPTION
This enables a cli that can return the path of the plugins, enabling
a more dynamic installation method of mitogen, one that does not
require changing ansible.cfg files.

