### PR TITLE
[BUGFIX] Respect SSH host key checking settings from host

### DIFF
--- a/ansible_mitogen/connection.py
+++ b/ansible_mitogen/connection.py
@@ -120,10 +120,15 @@ def _connect_ssh(spec):
     """
     Return ContextService arguments for an SSH connection.
     """
-    if C.HOST_KEY_CHECKING:
+    if spec.ssh_host_key_checking() == 'no' or spec.ssh_host_key_checking() is False:
+        check_host_keys = 'ignore'
+    elif spec.ssh_host_key_checking() == 'yes' or spec.ssh_host_key_checking() is True:
         check_host_keys = 'enforce'
     else:
-        check_host_keys = 'ignore'
+        if C.HOST_KEY_CHECKING:
+            check_host_keys = 'enforce'
+        else:
+            check_host_keys = 'ignore'
 
     # #334: tilde-expand private_key_file to avoid implementation difference
     # between Python and OpenSSH.

--- a/ansible_mitogen/transport_config.py
+++ b/ansible_mitogen/transport_config.py
@@ -197,6 +197,12 @@ class Spec(with_metaclass(abc.ABCMeta, object)):
         """
 
     @abc.abstractmethod
+    def ssh_host_key_checking(self):
+        """
+        Whether the SSH client should check host keys or not
+        """
+
+    @abc.abstractmethod
     def ssh_args(self):
         """
         The list of additional arguments that should be included in an SSH
@@ -383,6 +389,12 @@ class PlayContextSpec(Spec):
             self._connection.get_task_var('ansible_ssh_timeout') or
             self.timeout()
         )
+
+    def ssh_host_key_checking(self):
+        if self._connection.get_task_var('ansible_ssh_host_key_checking') is not None:
+            return self._connection.get_task_var('ansible_ssh_host_key_checking')
+        else:
+            return self._connection.get_task_var('ansible_host_key_checking')
 
     def ssh_args(self):
         return [

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,7 +21,12 @@ v0.2.10 (unreleased)
 To avail of fixes in an unreleased version, please download a ZIP file
 `directly from GitHub <https://github.com/dw/mitogen/>`_.
 
-*(no changes)*
+Mitogen for Ansible
+~~~~~~~~~~~~~~~~~~~
+* It is not possible to control SSH host key checking for certain host or group
+  of hosts by setting `ansible_ssh_host_key_checking` or `ansible_host_key_checking`
+  like stated in the ansible documentation for the SSH connection plugin:
+  https://docs.ansible.com/ansible/latest/plugins/connection/ssh.html#parameter-host_key_checking
 
 
 v0.2.9 (2019-11-02)


### PR DESCRIPTION
Use the host or group specific settings regarding SSH host key checking,
so the checking can be disabled for certain hosts or group of hosts.