### PR TITLE
Adds basic Ansible 2.9.6 support, tests use desired Ansible version now, and disabled flaky test on py3.6

### DIFF
--- a/.ci/ansible_install.py
+++ b/.ci/ansible_install.py
@@ -11,7 +11,7 @@ batches = [
         'pip install '
             '-r tests/requirements.txt '
             '-r tests/ansible/requirements.txt',
-        'pip install -q ansible=={}'.format(ci_lib.ANSIBLE_VERSION)
+        'pip install -q ansible=={0}'.format(ci_lib.ANSIBLE_VERSION)
     ]
 ]
 

--- a/.ci/ansible_install.py
+++ b/.ci/ansible_install.py
@@ -13,6 +13,9 @@ batches = [
     ]
 ]
 
+# separately install ansible based on version passed in from azure-pipelines.yml or .travis.yml
+batches.append("pip install -q ansible==%s", ci_lib.ANSIBLE_VERSION)
+
 batches.extend(
     ['docker pull %s' % (ci_lib.image_for_distro(distro),)]
     for distro in ci_lib.DISTROS

--- a/.ci/ansible_install.py
+++ b/.ci/ansible_install.py
@@ -6,15 +6,14 @@ batches = [
     [
         # Must be installed separately, as PyNACL indirect requirement causes
         # newer version to be installed if done in a single pip run.
+        # Separately install ansible based on version passed in from azure-pipelines.yml or .travis.yml
         'pip install "pycparser<2.19" "idna<2.7"',
         'pip install '
             '-r tests/requirements.txt '
             '-r tests/ansible/requirements.txt',
+        'pip install -q ansible=={}'.format(ci_lib.ANSIBLE_VERSION)
     ]
 ]
-
-# separately install ansible based on version passed in from azure-pipelines.yml or .travis.yml
-batches.append("pip install -q ansible==%s", ci_lib.ANSIBLE_VERSION)
 
 batches.extend(
     ['docker pull %s' % (ci_lib.image_for_distro(distro),)]

--- a/.ci/ansible_tests.py
+++ b/.ci/ansible_tests.py
@@ -66,10 +66,6 @@ with ci_lib.Fold('job_setup'):
     ci_lib.dump_file(inventory_path)
 
     if not ci_lib.exists_in_path('sshpass'):
-        # fix errors with apt-get update
-        run("sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 78BD65473CB3BD13")
-        run("sudo sed -i -e 's#deb https://downloads.apache.org/cassandra/debian 39x main#deb http://downloads.apache.org/cassandra/debian 39x main#g' /etc/apt/sources.list.d/cassandra.list")
-
         run("sudo apt-get update")
         run("sudo apt-get install -y sshpass")
 

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -46,6 +46,12 @@ jobs:
         MODE: mitogen
         DISTRO: centos6
 
+      Mito37Debian_27:
+        python.version: '3.7'
+        MODE: mitogen
+        DISTRO: debian
+        VER: 2.9.6
+
       #Py26CentOS7:
         #python.version: '2.7'
         #MODE: mitogen
@@ -97,3 +103,8 @@ jobs:
         python.version: '3.5'
         MODE: ansible
         VER: 2.8.0
+
+      Ansible_296_37:
+        python.version: '3.7'
+        MODE: ansible
+        VER: 2.9.6

--- a/.ci/localhost_ansible_install.py
+++ b/.ci/localhost_ansible_install.py
@@ -13,4 +13,7 @@ batches = [
     ]
 ]
 
+# separately install ansible based on version passed in from azure-pipelines.yml or .travis.yml
+batches.append("pip install -q ansible==%s", ci_lib.ANSIBLE_VERSION)
+
 ci_lib.run_batches(batches)

--- a/.ci/localhost_ansible_install.py
+++ b/.ci/localhost_ansible_install.py
@@ -6,14 +6,13 @@ batches = [
     [
         # Must be installed separately, as PyNACL indirect requirement causes
         # newer version to be installed if done in a single pip run.
+        # Separately install ansible based on version passed in from azure-pipelines.yml or .travis.yml
         'pip install "pycparser<2.19" "idna<2.7"',
         'pip install '
             '-r tests/requirements.txt '
             '-r tests/ansible/requirements.txt',
+        'pip install -q ansible=={}'.format(ci_lib.ANSIBLE_VERSION)
     ]
 ]
-
-# separately install ansible based on version passed in from azure-pipelines.yml or .travis.yml
-batches.append("pip install -q ansible==%s", ci_lib.ANSIBLE_VERSION)
 
 ci_lib.run_batches(batches)

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ matrix:
 
   include:
     # Debops tests.
+    # 2.9.6; 3.7 -> 2.7
+    - python: "3.7"
+      env: MODE=debops_common VER=2.9.6
     # 2.8.3; 3.6 -> 2.7
     - python: "3.6"
       env: MODE=debops_common VER=2.8.3
@@ -49,6 +52,9 @@ matrix:
 
     # ansible_mitogen tests.
 
+    # 2.9.6 -> {debian, centos6, centos7}
+    - python: "3.7"
+      env: MODE=ansible VER=2.9.6
     # 2.8.3 -> {debian, centos6, centos7}
     - python: "3.6"
       env: MODE=ansible VER=2.8.3
@@ -75,6 +81,8 @@ matrix:
     # 2.7 -> 2.6
     #- python: "2.7"
       #env: MODE=mitogen DISTRO=centos6
+    - python: "3.7"
+      env: MODE=mitogen DISTRO=centos7
     # 2.6 -> 2.7
     - python: "2.6"
       env: MODE=mitogen DISTRO=centos7

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
 
   include:
     # Debops tests.
-    # 2.9.6; 3.7 -> 2.7
+    # 2.9.6; 3.6 -> 2.7
     - python: "3.6"
       env: MODE=debops_common VER=2.9.6
     # 2.8.3; 3.6 -> 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: bionic
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: bionic
+dist: trusty
 
 notifications:
   email: false
@@ -37,7 +37,7 @@ matrix:
   include:
     # Debops tests.
     # 2.9.6; 3.7 -> 2.7
-    - python: "3.7"
+    - python: "3.6"
       env: MODE=debops_common VER=2.9.6
     # 2.8.3; 3.6 -> 2.7
     - python: "3.6"
@@ -53,7 +53,7 @@ matrix:
     # ansible_mitogen tests.
 
     # 2.9.6 -> {debian, centos6, centos7}
-    - python: "3.7"
+    - python: "3.6"
       env: MODE=ansible VER=2.9.6
     # 2.8.3 -> {debian, centos6, centos7}
     - python: "3.6"
@@ -81,7 +81,7 @@ matrix:
     # 2.7 -> 2.6
     #- python: "2.7"
       #env: MODE=mitogen DISTRO=centos6
-    - python: "3.7"
+    - python: "3.6"
       env: MODE=mitogen DISTRO=centos7
     # 2.6 -> 2.7
     - python: "2.6"

--- a/tests/ansible/requirements.txt
+++ b/tests/ansible/requirements.txt
@@ -1,5 +1,3 @@
-ansible==2.8.8; python_version >= '2.7'
-ansible<2.7; python_version < '2.7'
 paramiko==2.3.2  # Last 2.6-compat version.
 hdrhistogram==0.6.1
 PyYAML==3.11; python_version < '2.7'

--- a/tests/log_handler_test.py
+++ b/tests/log_handler_test.py
@@ -87,8 +87,8 @@ class StartupTest(testlib.RouterMixin, testlib.TestCase):
         self.assertTrue(expect in logs)
 
 StartupTest = unittest2.skipIf(
-    condition=sys.version_info < (2, 7),
-    reason="Message log flaky on Python < 2.7"
+    condition=sys.version_info < (2, 7) or sys.version_info >= (3, 6),
+    reason="Message log flaky on Python < 2.7 or >= 3.6"
 )(StartupTest)
 
 


### PR DESCRIPTION
There are features that'll need to be added later on (such as collections, see https://github.com/dw/mitogen/issues/652), but this PR will turn on ansible 2.9.6 tests and fix anything to get them passing