### PR TITLE
Correct latest ansible version supported

### DIFF
--- a/docs/ansible_detailed.rst
+++ b/docs/ansible_detailed.rst
@@ -145,7 +145,7 @@ Testimonials
 Noteworthy Differences
 ----------------------
 
-* Ansible 2.3-2.8 are supported along with Python 2.6, 2.7, 3.6 and 3.7. Verify
+* Ansible 2.3-2.9 are supported along with Python 2.6, 2.7, 3.6 and 3.7. Verify
   your installation is running one of these versions by checking ``ansible
   --version`` output.
 


### PR DESCRIPTION
Self-explanatory. (Might it be worth removing this from the docs lest it continue to get stale?)