### PR TITLE
Handles no tmpdir in fetch command for old ansible versions

### DIFF
--- a/ansible_mitogen/plugins/action/mitogen_fetch.py
+++ b/ansible_mitogen/plugins/action/mitogen_fetch.py
@@ -157,6 +157,10 @@ class ActionModule(ActionBase):
                 result.update(dict(changed=False, md5sum=local_md5, file=source, dest=dest, checksum=local_checksum))
 
         finally:
-            self._remove_tmp_path(self._connection._shell.tmpdir)
+            try:
+                self._remove_tmp_path(self._connection._shell.tmpdir)
+            except AttributeError:
+                # .tmpdir was added to ShellModule in v2.6.0, so old versions don't have it
+                pass
 
         return result


### PR DESCRIPTION
Fixes #716 

There was no `.tmpdir` or `_tmpdir` attr on `ShellModule` for ansible 2.4.2, and I did some research and it only existed in AnsibleModule in ansible 2.6.0+. This patch ignores the error; I couldn't figure out if there even was a tmpdir for me to remove.