### PR TITLE
updated ansible docs to reflect ansible 2.9 support

### DIFF
--- a/docs/ansible_detailed.rst
+++ b/docs/ansible_detailed.rst
@@ -145,7 +145,7 @@ Testimonials
 Noteworthy Differences
 ----------------------
 
-* Ansible 2.3-2.8 are supported along with Python 2.6, 2.7, 3.6 and 3.7. Verify
+* Ansible 2.3-2.9 are supported along with Python 2.6, 2.7, 3.6 and 3.7. Verify
   your installation is running one of these versions by checking ``ansible
   --version`` output.
 


### PR DESCRIPTION
I changed a single byte in the ansible doc, just to show its not capped at ansible 2.8 anymore

I guess that makes me a a contributor to this project now! Will look great on my resume! ;-)

