### PR TITLE
WIP: Fixes: Mitogen fails if file is changed during transfer and validate_checksum is false

### DIFF
--- a/ansible_mitogen/connection.py
+++ b/ansible_mitogen/connection.py
@@ -1003,7 +1003,7 @@ class Connection(ansible.plugins.connection.ConnectionBase):
         )
         return rc, stdout, stderr
 
-    def fetch_file(self, in_path, out_path):
+    def fetch_file(self, in_path, out_path, validate_checksum=True):
         """
         Implement fetch_file() by calling the corresponding
         ansible_mitogen.target function in the target.
@@ -1018,7 +1018,8 @@ class Connection(ansible.plugins.connection.ConnectionBase):
             context=self.context,
             # in_path may be AnsibleUnicode
             in_path=mitogen.utils.cast(in_path),
-            out_path=out_path
+            out_path=out_path,
+            validate_checksum=validate_checksum,
         )
 
     def put_data(self, out_path, data, mode=None, utimes=None):

--- a/ansible_mitogen/plugins/action/mitogen_fetch.py
+++ b/ansible_mitogen/plugins/action/mitogen_fetch.py
@@ -132,7 +132,7 @@ class ActionModule(ActionBase):
                 makedirs_safe(os.path.dirname(dest))
 
                 # fetch the file and check for changes
-                self._connection.fetch_file(source, dest)
+                self._connection.fetch_file(source, dest, validate_checksum=validate_checksum)
                 new_checksum = secure_hash(dest)
                 # For backwards compatibility. We'll return None on FIPS enabled systems
                 try:

--- a/ansible_mitogen/target.py
+++ b/ansible_mitogen/target.py
@@ -171,7 +171,7 @@ def get_small_file(context, path):
     return service.get(path)
 
 
-def transfer_file(context, in_path, out_path, sync=False, set_owner=False):
+def transfer_file(context, in_path, out_path, sync=False, set_owner=False, validate_checksum=True):
     """
     Streamily download a file from the connection multiplexer process in the
     controller.
@@ -191,6 +191,8 @@ def transfer_file(context, in_path, out_path, sync=False, set_owner=False):
     :param bool set_owner:
         If :data:`True`, look up the metadata username and group on the local
         system and file the file owner using :func:`os.fchmod`.
+    :param bool validate_checksum:
+        If :data:`True`, file must be unchanged during transfer.
     """
     out_path = os.path.abspath(out_path)
     fd, tmp_path = tempfile.mkstemp(suffix='.tmp',
@@ -205,6 +207,7 @@ def transfer_file(context, in_path, out_path, sync=False, set_owner=False):
                 context=context,
                 path=in_path,
                 out_fp=fp,
+                validate_checksum=validate_checksum,
             )
             if not ok:
                 raise IOError('transfer of %r was interrupted.' % (in_path,))


### PR DESCRIPTION
Fixes: Mitogen fails if file is changed during transfer and validate_checksum is false

Thanks for creating a PR! Here's a quick checklist to pay attention to:

* Please add an entry to docs/changelog.rst as appropriate.

* Has some new parameter been added or semantics modified somehow? Please
  ensure relevant documentation is updated in docs/ansible.rst and
  docs/api.rst.

* If it's for new functionality, is there at least a basic test in either
  tests/ or tests/ansible/ covering it?

* If it's for a new connection method, please try to stub out the
  implementation as in tests/data/stubs/, so that construction can be tested
  without having a working configuration.

