### PR TITLE
ssh: Match newer ssh host key prompt that accepts the fingerprint

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,7 +21,8 @@ v0.2.10 (unreleased)
 To avail of fixes in an unreleased version, please download a ZIP file
 `directly from GitHub <https://github.com/dw/mitogen/>`_.
 
-*(no changes)*
+* :gh:issue:`756` ssh connections with `check_host_keys='accept'` would
+  timeout, when using recent OpenSSH client versions.
 
 
 v0.2.9 (2019-11-02)

--- a/mitogen/ssh.py
+++ b/mitogen/ssh.py
@@ -72,7 +72,10 @@ PASSWORD_PROMPT_PATTERN = re.compile(
 )
 
 HOSTKEY_REQ_PATTERN = re.compile(
-    b(r'are you sure you want to continue connecting \(yes/no\)\?'),
+    b(
+            r'are you sure you want to continue connecting '
+            r'\(yes/no(?:/\[fingerprint\])?\)\?'
+    ),
     re.I
 )
 


### PR DESCRIPTION
This fixes an ERROR in test_accept_enforce_host_keys() while running the
test suite.

Fixes #75

