### PR TITLE
tests: Fix AttributeError in callback plugins used by test suite

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,9 @@ To avail of fixes in an unreleased version, please download a ZIP file
 
 * :gh:issue:`756` ssh connections with `check_host_keys='accept'` would
   timeout, when using recent OpenSSH client versions.
+* :gh:issue:`758` fix initilialisation of callback plugins in test suite, to
+  to address a `KeyError` in
+  :method:`ansible.plugins.callback.CallbackBase.v2_runner_on_start`
 
 
 v0.2.9 (2019-11-02)

--- a/tests/ansible/lib/callback/nice_stdout.py
+++ b/tests/ansible/lib/callback/nice_stdout.py
@@ -20,6 +20,8 @@ DefaultModule = callback_loader.get('default', class_only=True)
 DOCUMENTATION = '''
     callback: nice_stdout
     type: stdout
+    extends_documentation_fragment:
+      - default_callback
     options:
       check_mode_markers:
         name: Show markers when running in check mode
@@ -74,6 +76,10 @@ def printi(tio, obj, key=None, indent=0):
 
 
 class CallbackModule(DefaultModule):
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'nice_stdout'
+
     def _dump_results(self, result, *args, **kwargs):
         try:
             tio = io.StringIO()

--- a/tests/ansible/lib/callback/profile_tasks.py
+++ b/tests/ansible/lib/callback/profile_tasks.py
@@ -37,6 +37,7 @@ class CallbackModule(CallbackBase):
     A plugin for timing tasks
     """
     def __init__(self):
+        super(CallbackModule, self).__init__()
         self.stats = {}
         self.current = None
 


### PR DESCRIPTION
CALLBACK_VERSION et al are documented as required in
https://docs.ansible.com/ansible/2.10/dev_guide/developing_plugins.html#callback-plugins.
The need for document_fragment is noted in
https://github.com/ansible/ansible/blob/cfa8075537f5fa83ca5bfe3170373aaef9ce932f/lib/ansible/plugins/callback/default.py#L28-L32

Fixes #758

This addresses the following error, seen while running
`ansible_tests.py`.

```
TASK [Gathering Facts gather_timeout=10, gather_subset=['all']]
****************
task path:
/home/alex/src/mitogen/tests/ansible/regression/issue_109__target_has_old_ansible_installed.yml:4
[WARNING]: Failure using method (v2_runner_on_start) in callback plugin
(<ansible.plugins.callback.nice_stdout.CallbackModule object at
0x7f76b3dad090>): 'show_per_host_start'
Callback Exception:
File
"/home/alex/src/mitogen/.tox/py27-ansible2.10/lib/python2.7/site-packages/ansible/executor/task_queue_manager.py",
line 372, in send_callback
    method(*new_args, **kwargs)
File
"/home/alex/src/mitogen/.tox/py27-ansible2.10/lib/python2.7/site-packages/ansible/plugins/callback/default.py",
line 240, in v2_runner_on_start
    if self.get_option('show_per_host_start'):
File
"/home/alex/src/mitogen/.tox/py27-ansible2.10/lib/python2.7/site-packages/ansible/plugins/callback/__init__.py",
line 91, in get_option
    return self._plugin_options[k]
Callback Exception:
File
"/home/alex/src/mitogen/.tox/py27-ansible2.10/lib/python2.7/site-packages/ansible/executor/task_queue_manager.py",
line 372, in send_callback
    method(*new_args, **kwargs)
File
"/home/alex/src/mitogen/.tox/py27-ansible2.10/lib/python2.7/site-packages/ansible/plugins/callback/default.py",
line 240, in v2_runner_on_start
    if self.get_option('show_per_host_start'):
File
"/home/alex/src/mitogen/.tox/py27-ansible2.10/lib/python2.7/site-packages/ansible/plugins/callback/__init__.py",
line 91, in get_option
    return self._plugin_options[k]
[task 339882] 00:00:08.172036 D ansible_mitogen.affinity: CPU mask for
WorkerProcess: 0x000004
Callback Exception:
File
"/home/alex/src/mitogen/.tox/py27-ansible2.10/lib/python2.7/site-packages/ansible/executor/task_queue_manager.py",
line 372, in send_callback
    method(*new_args, **kwargs)
File
"/home/alex/src/mitogen/.tox/py27-ansible2.10/lib/python2.7/site-packages/ansible/plugins/callback/default.py",
line 240, in v2_runner_on_start
    if self.get_option('show_per_host_start'):
File
"/home/alex/src/mitogen/.tox/py27-ansible2.10/lib/python2.7/site-packages/ansible/plugins/callback/__init__.py",
line 91, in get_option
    return self._plugin_options[k]
```


Thanks for creating a PR! Here's a quick checklist to pay attention to:

* Please add an entry to docs/changelog.rst as appropriate.

* Has some new parameter been added or semantics modified somehow? Please
  ensure relevant documentation is updated in docs/ansible.rst and
  docs/api.rst.

* If it's for new functionality, is there at least a basic test in either
  tests/ or tests/ansible/ covering it?

* If it's for a new connection method, please try to stub out the
  implementation as in tests/data/stubs/, so that construction can be tested
  without having a working configuration.

