### PR TITLE
Add ansible.legacy.setup to be fixed on py3.5

### DIFF
--- a/ansible_mitogen/planner.py
+++ b/ansible_mitogen/planner.py
@@ -553,7 +553,7 @@ def _fix_py35(invocation, module_source):
     We replace a relative import in the setup module with the actual full file path
     This works in vanilla Ansible but not in Mitogen otherwise
     """
-    if invocation.module_name in {'ansible.builtin.setup', 'setup'} and \
+    if invocation.module_name in {'ansible.builtin.setup', 'ansible.legacy.setup', 'setup'} and \
             invocation.module_path not in invocation._overridden_sources:
         # in-memory replacement of setup module's relative import
         # would check for just python3.5 and run this then but we don't know the


### PR DESCRIPTION
This fix was already mentioned in https://github.com/dw/mitogen/pull/715#issuecomment-731601226 but somehow seems to have not made it into the final version.

This showed up as an actual issue on an Ubuntu 16.04 host for me using `ansible-base==2.10.4` and `mitogen==0.3.0-rc.0`.