### PR TITLE
Bump copyright year and use generic author name (testing Travis)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019, David Wilson
+Copyright 2021, the Mitogen authors
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@ import mitogen
 VERSION = '%s.%s.%s' % mitogen.__version__
 
 author = u'Network Genomics'
-copyright = u'2019, Network Genomics'
+copyright = u'2021, the Mitogen authors'
 exclude_patterns = ['_build', '.venv']
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinxcontrib.programoutput', 'domainrefs']
 


### PR DESCRIPTION
This is just to ensure the Travis integration is working correctly.