### PR TITLE
SSH: support TOTP password prompts, as used by google-authenticator-libpam

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,7 @@ v0.3.4.dev0
   resource leaks.
 * :gh:issue:`659` Removed :mod:`mitogen.compat.simplejson`, not needed with Python 2.7+, contained Python 3.x syntax errors
 * :gh:issue:`983` CI: Removed PyPI faulthandler requirement from tests
+* :gh:issue:`998` SSH: Added support for TOTP password prompts (i.e. 'Verification code: '), as used by google-authenticator-libpam
 
 v0.3.3 (2022-06-03)
 -------------------

--- a/mitogen/ssh.py
+++ b/mitogen/ssh.py
@@ -66,8 +66,12 @@ hostkey_failed_msg = (
 )
 
 # sshpass uses 'assword' because it doesn't lowercase the input.
+# 'password': standard password prompt
+# 'verification code': TOTP prompt(as used by e.g. google-authenticator-libpam)
+# These should also match 'password & verification code' for password and TOTP
+# prompt (as used by e.g. google-authenticator-libpam)
 PASSWORD_PROMPT_PATTERN = re.compile(
-    b('password'),
+    b('(password|verification code)'),
     re.I
 )
 


### PR DESCRIPTION
TOTP prompts 'Verification code: ' as used by google-authenticator-libpam are now supported.
Reference: https://github.com/google/google-authenticator-libpam/blob/366ace3e5849d0d259915ddff22c8ec55e40b3ad/src/pam_google_authenticator.c#LL61C24-L61C42

Closes #998.