### PR TITLE
Handle condition going from privileged to non-privileged user

### DIFF
--- a/ansible_mitogen/runner.py
+++ b/ansible_mitogen/runner.py
@@ -366,10 +366,15 @@ class Runner(object):
         """
         For situations like sudo to a non-privileged account, CWD could be
         $HOME of the old account, which could have mode go=, which means it is
-        impossible to restore the old directory, so don't even try.
+        impossible to restore the old directory. Fallback to a neutral temp if so.
         """
         if self.cwd:
-            os.chdir(self.cwd)
+            try:
+                os.chdir(self.cwd)
+            except OSError:
+                LOG.debug('%r: could not CHDIR to %r fallback to %r',
+                          self, self.cwd, self.good_temp_dir)
+                os.chdir(self.good_temp_dir)
 
     def _setup_environ(self):
         """

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -536,6 +536,7 @@ v0.3.9 (2024-08-13)
 v0.3.8 (2024-07-30)
 -------------------
 
+* :gh:issue:`636` os.chdir fails if the sudo/become user lacks adequate permissions to chdir prior to task
 * :gh:issue:`952` Fix Ansible `--ask-become-pass`, add test coverage
 * :gh:issue:`957` Fix Ansible exception when executing against 10s of hosts
   "ValueError: filedescriptor out of range in select()"


### PR DESCRIPTION
in which the cwd disables descent. Fall back to Mitogen's temporary directory. Fixes #636.

This is a rebase of #805 