### PR TITLE
CI: replace `stdout=yaml` with `result_format=yaml` for Ansible >= 6 tests

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,9 @@ Running Ansible 12 + Mitogen will currently print a deprecation warning
 Ansible + Mitogen will still work for now. Mitogen is considering alternatives
 to strategy plugins under :gh:issue:`1278`.
 
+* :gh:issue:`1285` CI: use `result_format = yaml` for Ansible test output,
+  instead of deprecated `stdout_callback = yaml`
+
 
 v0.3.25a2 (2025-06-21)
 ----------------------

--- a/tests/ansible/ansible.cfg
+++ b/tests/ansible/ansible.cfg
@@ -1,5 +1,7 @@
 [defaults]
 any_errors_fatal = true
+# Ansible >= 6 (ansible-core >= 2.13)
+callback_result_format = yaml
 # callbacks_enabled was added in Ansible 4 (ansible-core 2.11).
 # profile_tasks: Displays timing for each task and summary table of top N tasks
 # timer: Displays "Playbook run took 0 days, 0 hours, ..."
@@ -17,13 +19,13 @@ strategy_plugins = ../../ansible_mitogen/plugins/strategy
 inventory_plugins = lib/inventory
 action_plugins = lib/action
 callback_plugins = lib/callback
-stdout_callback = yaml
 vars_plugins = lib/vars
 library = lib/modules
 filter_plugins = lib/filters
 module_utils = lib/module_utils
 retry_files_enabled = False
-show_task_path_on_failure = true  # Added in ansible-core 2.11
+# Ansible >= 4 (ansible-core >= 2.11)
+show_task_path_on_failure = true
 display_args_to_stdout = True
 forks = 100
 

--- a/tests/ansible/integration/process/unix_socket_cleanup.yml
+++ b/tests/ansible/integration/process/unix_socket_cleanup.yml
@@ -11,6 +11,8 @@
     vars:
       ansible_python_interpreter: "{{ ansible_playbook_python }}"
     shell: >-
+      ANSIBLE_CALLBACK_RESULT_FORMAT=json
+      ANSIBLE_LOAD_CALLBACK_PLUGINS=false
       ANSIBLE_STRATEGY=mitogen_linear
       ANSIBLE_SSH_ARGS="-o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa"
       ANSIBLE_VERBOSITY="{{ ansible_verbosity }}"

--- a/tests/ansible/integration/runner/missing_module.yml
+++ b/tests/ansible/integration/runner/missing_module.yml
@@ -5,6 +5,8 @@
     - name: Run missing_module
       connection: local
       environment:
+        ANSIBLE_CALLBACK_RESULT_FORMAT: json
+        ANSIBLE_LOAD_CALLBACK_PLUGINS: "false"
         ANSIBLE_STRATEGY:  "{{ lookup('env', 'ANSIBLE_STRATEGY') | mandatory }}"
         ANSIBLE_VERBOSITY: "{{ ansible_verbosity }}"
       vars:

--- a/tests/ansible/integration/ssh/timeouts.yml
+++ b/tests/ansible/integration/ssh/timeouts.yml
@@ -13,6 +13,8 @@
     - name: Cause Ansible connection timeout
       connection: local
       environment:
+        ANSIBLE_CALLBACK_RESULT_FORMAT: json
+        ANSIBLE_LOAD_CALLBACK_PLUGINS: "false"
         ANSIBLE_SSH_TIMEOUT: 10
         ANSIBLE_STRATEGY:  "{{ lookup('env', 'ANSIBLE_STRATEGY') | mandatory }}"
         ANSIBLE_VERBOSITY: "{{ ansible_verbosity }}"

--- a/tests/ansible/integration/ssh/variables.yml
+++ b/tests/ansible/integration/ssh/variables.yml
@@ -19,6 +19,8 @@
     - name: ansible_user, ansible_ssh_private_key_file
       shell: >
         ANSIBLE_ANY_ERRORS_FATAL=false
+        ANSIBLE_CALLBACK_RESULT_FORMAT=json
+        ANSIBLE_LOAD_CALLBACK_PLUGINS=false
         ANSIBLE_STRATEGY=mitogen_linear
         ANSIBLE_SSH_ARGS="-o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa"
         ANSIBLE_VERBOSITY="{{ ansible_verbosity }}"
@@ -37,6 +39,8 @@
     - name: ansible_user, wrong ansible_ssh_private_key_file
       shell: >
         ANSIBLE_ANY_ERRORS_FATAL=false
+        ANSIBLE_CALLBACK_RESULT_FORMAT=json
+        ANSIBLE_LOAD_CALLBACK_PLUGINS=false
         ANSIBLE_STRATEGY=mitogen_linear
         ANSIBLE_SSH_ARGS="-o HostKeyAlgorithms=+ssh-rsa -o PubkeyAcceptedKeyTypes=+ssh-rsa"
         ANSIBLE_VERBOSITY="{{ ansible_verbosity }}"

--- a/tests/ansible/integration/stub_connections/setns_lxc.yml
+++ b/tests/ansible/integration/stub_connections/setns_lxc.yml
@@ -15,6 +15,8 @@
 
     - name: Run stub-lxc-info.py
       environment:
+        ANSIBLE_CALLBACK_RESULT_FORMAT: json
+        ANSIBLE_LOAD_CALLBACK_PLUGINS: "false"
         ANSIBLE_STRATEGY:  "{{ lookup('env', 'ANSIBLE_STRATEGY') | mandatory }}"
         ANSIBLE_VERBOSITY: "{{ ansible_verbosity }}"
       command: |

--- a/tests/ansible/integration/stub_connections/setns_lxd.yml
+++ b/tests/ansible/integration/stub_connections/setns_lxd.yml
@@ -15,6 +15,8 @@
 
     - name: Run ansible stub-lxc.py
       environment:
+        ANSIBLE_CALLBACK_RESULT_FORMAT: json
+        ANSIBLE_LOAD_CALLBACK_PLUGINS: "false"
         ANSIBLE_STRATEGY:  "{{ lookup('env', 'ANSIBLE_STRATEGY') | mandatory }}"
         ANSIBLE_VERBOSITY: "{{ ansible_verbosity }}"
       command: |

--- a/tox.ini
+++ b/tox.ini
@@ -112,6 +112,9 @@ setenv =
     NOCOVERAGE_ERASE = 1
     NOCOVERAGE_REPORT = 1
     PIP_CONSTRAINT={toxinidir}/tests/constraints.txt
+    # Superceded in Ansible >= 6 (ansible-core >= 2.13) by result_format=yaml
+    # Deprecated in Ansible 12 (ansible-core 2.19)
+    ansible{2.10,3-5}: DEFAULT_STDOUT_CALLBACK=yaml
     # Print warning on the first occurence at each module:linenno in Mitogen. Available Python 2.7, 3.2+.
     PYTHONWARNINGS=default:::ansible_mitogen,default:::mitogen
     # Ansible 6 - 8 (ansible-core 2.13 - 2.15) require Python 2.7 or >= 3.5 on targets


### PR DESCRIPTION
Ansible >= 12 (ansible-core >= 2.19) deprecates `stdout_callback=yaml`, superceded by `callback_result_format=yaml`. There is a change in behaviour: `callback_result_format` applies to output of both `ansible-playbook` _and_
`ansible`.

Tests that run `ansible` in a subprocess are now explicitly configured to use json (even if they don't inspect that output yet) for more assert-able output across all versions of Ansible.

fixes #1285 