### PR TITLE
mitogen: Prevent hung bootstrap processes, add 5   second timeout to first stage

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,9 @@ To avail of fixes in an unreleased version, please download a ZIP file
 In progress (unreleased)
 ------------------------
 
+* :gh:issue:`1266` :mod:`mitogen`: Prevent hung bootstrap processes, add 5
+  second timeout to first stage
+
 
 v0.3.34 (2025-11-27)
 --------------------


### PR DESCRIPTION
Since using select.select() in the first stage (to handle an obscure corner case where stdin appears to be non-blocking) there has been a report of first stage processes running for ever in an infinite loop - reading 0 bytes from stdin.

This attempts to do an end run around that problem by aborting if the bootstrap takes longer than a few seconds for *any* reason. Existing retry logic should deal with it as before.

refs #1306, #1307, #1348 
