### PR TITLE
ansible_mitogen: Use INTERPRETER_PYTHON_FALLBACK as python candidates

### DIFF
--- a/ansible_mitogen/mixins.py
+++ b/ansible_mitogen/mixins.py
@@ -470,18 +470,7 @@ class ActionModuleMixin(ansible.plugins.action.ActionBase):
         # chicken-and-egg issue, mitogen needs a python to run low_level_execute_command
         # which is required by Ansible's discover_interpreter function
         if self._mitogen_discovering_interpreter:
-            possible_pythons = [
-                '/usr/bin/python',
-                'python3',
-                'python3.7',
-                'python3.6',
-                'python3.5',
-                'python2.7',
-                'python2.6',
-                '/usr/libexec/platform-python',
-                '/usr/bin/python3',
-                'python'
-            ]
+            possible_pythons = self._mitogen_interpreter_candidates
         else:
             # not used, just adding a filler value
             possible_pythons = ['python']
@@ -492,12 +481,15 @@ class ActionModuleMixin(ansible.plugins.action.ActionBase):
                 rc, stdout, stderr = self._connection.exec_command(
                     cmd, in_data, sudoable, mitogen_chdir=chdir,
                 )
-            # TODO: what exception is thrown?
-            except:
+            except BaseException as exc:
                 # we've reached the last python attempted and failed
                 if possible_python == possible_pythons[-1]:
                     raise
                 else:
+                    LOG.debug(
+                        '%r._low_level_execute_command: candidate=%r ignored: %s, %r',
+                        self, possible_python, type(exc), exc,
+                    )
                     continue
 
         stdout_text = to_text(stdout, errors=encoding_errors)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,9 @@ To avail of fixes in an unreleased version, please download a ZIP file
 In progress (unreleased)
 ------------------------
 
+* :gh:issue:`1132` :mod:`ansible_mitogen` During intrepreter discovery use
+  Ansible ``INTERPRETER_PYTHON_FALLBACK`` config as list of candidates
+
 
 v0.3.34 (2025-11-27)
 --------------------


### PR DESCRIPTION
This shouldn't change the interpreter ultimately chosen by Ansible. It should only improve the hit rate of performing interpreter discovery, particular in cases where only pythonX.Y is present on the target.

Interpreter discovery may take longer or shorter, depending on the Ansible version and the interpreters present on the target.

fixes #1380 