### PR TITLE
WIP: atexit handling in Ansible modules

### DIFF
--- a/tests/ansible/lib/modules/atexit_cleanup.py
+++ b/tests/ansible/lib/modules/atexit_cleanup.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import atexit
+import errno
+import os
+
+from ansible.module_utils.basic import AnsibleModule
+
+CLEANUP_FILE = '/tmp/mitogen_test_atexit_cleanup_canary.txt'
+
+
+def cleanup(file):
+    try:
+        os.unlink(file)
+    except OSError as exc:
+        if exc.errno == errno.ENOENT:
+            pass
+        raise
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={},
+    )
+
+    atexit.register(cleanup, CLEANUP_FILE)
+
+    with open(CLEANUP_FILE, 'wb') as f:
+        f.truncate()
+
+    result = {
+        'changed': True,
+    }
+    module.exit_json(**result)
+
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/ansible/regression/all.yml
+++ b/tests/ansible/regression/all.yml
@@ -19,3 +19,4 @@
 - import_playbook: issue_1066__add_host__host_key_checking.yml
 - import_playbook: issue_1079__wait_for_connection_timeout.yml
 - import_playbook: issue_1087__template_streamerror.yml
+- import_playbook: issue_1360_atexit_cleanup.yml

--- a/tests/ansible/regression/issue_1360_atexit_cleanup.yml
+++ b/tests/ansible/regression/issue_1360_atexit_cleanup.yml
@@ -1,0 +1,34 @@
+- name: regression/issue_1360_atexit_cleanup.yml
+  hosts: test-targets
+  gather_facts: false
+  become: false
+  vars:
+    cleanup_canary_path: /tmp/mitogen_test_atexit_cleanup_canary.txt
+  tasks:
+    - block:
+        - name: Remove lingering cleanup canary
+          file:
+            path: "{{ cleanup_canary_path }}"
+            state: absent
+
+        - name: Run module with atexit cleanup
+          atexit_cleanup:
+
+        - name: Trigger exit of remote process
+          meta: reset_connection
+
+        - name: Check presence of cleanup canary
+          stat:
+            path:  "{{ cleanup_canary_path }}"
+          register:  cleanup_canary_stat
+
+        - assert:
+            that:
+              - not cleanup_canary_stat.stat.exists
+      always:
+        - name: Cleanup
+          file:
+            path: "{{ cleanup_canary_path }}"
+            state: absent
+  tags:
+    - issue_1360


### PR DESCRIPTION
Pin down if (and when) callbacks added by `atexit.register()` are executed. Fix or document shortcomings.

refs #1360
