### PR TITLE
testlib: Fix hanging tests

### DIFF
--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -172,11 +172,11 @@ def _have_cmd(args):
 
 
 def have_python2():
-    return _have_cmd(['python2'])
+    return _have_cmd(['python2', '--version'])
 
 
 def have_python3():
-    return _have_cmd(['python3'])
+    return _have_cmd(['python3', '--version'])
 
 
 def have_sudo_nopassword():


### PR DESCRIPTION
When I run

$ MITOGEN_LOG_LEVEL=debug SKIP_ANSIBLE=1 ./run_tests -v -k first_stage_test.CommandLineTest

on an interactive Shell (with a tty), it ends in a hanging process as the `have_python2` and `have_python3` ends up in an interactive Python shell. Therefore check the Python version instead.