### PR TITLE
tests: Handle builtin _ssl module on Linux

### DIFF
--- a/tests/fork_test.py
+++ b/tests/fork_test.py
@@ -27,8 +27,12 @@ import plain_old_module
 
 
 def _find_ssl_linux():
+    ssl_object_path = getattr(_ssl, "__file__", None)
+    if ssl_object_path is None:
+        # No __file__ because it's builtin
+        ssl_object_path = sys.executable
     proc = subprocess.Popen(
-        ['ldd', _ssl.__file__],
+        ['ldd', ssl_object_path],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
     )
     b_stdout, b_stderr = proc.communicate()


### PR DESCRIPTION
Certainly for my local Python copy (3.14, installed via uv), the `_ssl` module is builtin, not an `.so` and so the `_ssl.__file__` check fails with a lack of `__file__`. This PR fixes that by looking for an SSL library ref from the main Python executable if `_ssl` doesn't have `__file__`