### PR TITLE
Experiment: Configurable Pickle protocol version

### DIFF
--- a/mitogen/__init__.py
+++ b/mitogen/__init__.py
@@ -61,6 +61,7 @@ parent_ids = []
 
 import os
 _default_profiling = os.environ.get('MITOGEN_PROFILING') is not None
+pickle_protocol = int(os.environ.get('MITOGEN_PICKLE_PROTOCOL', '2'), 10)
 del os
 
 

--- a/mitogen/core.py
+++ b/mitogen/core.py
@@ -922,10 +922,10 @@ class Message(object):
         """
         self = cls(**kwargs)
         try:
-            self.data = pickle__dumps(obj, protocol=2)
+            self.data = pickle__dumps(obj, protocol=mitogen.pickle_protocol)
         except pickle.PicklingError:
             e = sys.exc_info()[1]
-            self.data = pickle__dumps(CallError(e), protocol=2)
+            self.data = pickle__dumps(CallError(e), protocol=mitogen.pickle_protocol)
         return self
 
     def reply(self, msg, router=None, **kwargs):
@@ -4185,6 +4185,7 @@ class ExternalContext(object):
         mitogen.context_id = self.config['context_id']
         mitogen.parent_ids = self.config['parent_ids'][:]
         mitogen.parent_id = mitogen.parent_ids[0]
+        mitogen.pickle_protocol = self.config['pickle_protocol']
 
     def _nullify_stdio(self):
         """

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -1508,6 +1508,7 @@ class Connection(object):
             'whitelist': self._router.get_module_whitelist(),
             'blacklist': self._router.get_module_blacklist(),
             'max_message_size': self.options.max_message_size,
+            'pickle_protocol': mitogen.pickle_protocol,
             'version': mitogen.__version__,
         }
 

--- a/tests/bench/throughput.py
+++ b/tests/bench/throughput.py
@@ -9,7 +9,7 @@ import tempfile
 import mitogen
 import mitogen.core
 import mitogen.service
-import ansible_mitogen.affinity
+#import ansible_mitogen.affinity
 
 
 def prepare():
@@ -63,7 +63,7 @@ def main(router):
     parser.add_option('--debug', action='store_true')
     opts, args = parser.parse_args()
 
-    ansible_mitogen.affinity.policy.assign_muxprocess()
+    #ansible_mitogen.affinity.policy.assign_muxprocess()
 
     bigfile = tempfile.NamedTemporaryFile()
     fill_with_random(bigfile, 1048576*512)
@@ -77,9 +77,9 @@ def main(router):
         run_test(router, bigfile, 'local()', context)
         context.shutdown(wait=True)
 
-        context = router.sudo(username=opts.sudo_user, debug=opts.debug)
-        run_test(router, bigfile, 'sudo()', context)
-        context.shutdown(wait=True)
+        #context = router.sudo(username=opts.sudo_user, debug=opts.debug)
+        #run_test(router, bigfile, 'sudo()', context)
+        #context.shutdown(wait=True)
 
         context = router.ssh(
             hostname=args[0],


### PR DESCRIPTION
Mitogen currentl uses Pickle protocol 2, regardless of the Python versions. This constrains performance under Python 3 (#485). Configurable Pickle protocol would improve performance when exclusively using Python 3

## Protocol 2
```console
➜  mitogen git:(mitogen.pickle_protocol) ✗ .venv/bin/python3.14 tests/bench/throughput.py --ssh-host d13.lan --ssh-python python3 
2
Testing local()...
local() took 2734.70 ms to transfer 512.00 MiB, 187.22 MiB/s
Testing ssh(compression=False)...
ssh(compression=False) took 36714.61 ms to transfer 512.00 MiB, 13.95 MiB/s
Testing ssh(compression=True)...
ssh(compression=True) took 43327.35 ms to transfer 512.00 MiB, 11.82 MiB/s
```
## Protocol 3
```console
➜  mitogen git:(master) ✗ MITOGEN_PICKLE_PROTOCOL=3 .venv/bin/python3.14 tests/bench/throughput.py --ssh-host d13.lan --ssh-python python3
3
Testing local()...
local() took 324.69 ms to transfer 512.00 MiB, 1576.91 MiB/s
Testing ssh(compression=False)...
ssh(compression=False) took 22553.84 ms to transfer 512.00 MiB, 22.70 MiB/s
Testing ssh(compression=True)...
ssh(compression=True) took 21976.54 ms to transfer 512.00 MiB, 23.30 MiB/s
```
