### PR TITLE
mitogen: Format Message src & dst as `<context>:<handle>`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,8 @@ v0.3.37 (2026-01-08)
   :py:class:`importlib.resource.abc.ResourceReader` protocol
 * :gh:issue:`1407` :mod:`mitogen`: Fix :exc:`AttributeError` in
   :mod:`mitogen.profiler`
+* :gh:issue:`1418` :mod:`mitogen`: Format :class:`mitogen.core.Message` source
+   and destination as ``<context>:<handle>``, for clarity
 
 
 v0.3.36 (2025-12-01)

--- a/mitogen/core.py
+++ b/mitogen/core.py
@@ -1004,9 +1004,14 @@ class Message(object):
         return obj
 
     def __repr__(self):
-        return 'Message(%r, %r, %r, %r, %r, %r..%d)' % (
-            self.dst_id, self.src_id, self.auth_id, self.handle,
-            self.reply_to, (self.data or '')[:50], len(self.data)
+        if len(self.data) > 60:
+            head, tail, size = self.data[:25], self.data[-25:], len(self.data)
+            data_summary = b('%s .. %s %d bytes') % (head, tail, size)
+        else:
+            data_summary = self.data
+        return 'Message(src=%r:%r dst=%r:%r auth_id=%r %r)' % (
+            self.src_id, self.reply_to, self.dst_id, self.handle, self.auth_id,
+            data_summary,
         )
 
 


### PR DESCRIPTION
The notation is inspired by host:port notation in a URL. In Mitogen context id and handles fill roughly the same role as IP and port in TCP or UDP.