### PR TITLE
Experiment: eliminate pickle encoding where possible

### DIFF
--- a/mitogen/master.py
+++ b/mitogen/master.py
@@ -1295,8 +1295,7 @@ class ResourceResponder(object):
         stream = self._router.stream_by_id(msg.src_id)
         if stream is None:
             return
-        fullname_b, resource_b = msg.unpickle()
-        fullname, resource = fullname_b.decode(), resource_b.decode()
+        fullname, resource = msg.unpickle()
         try:
             content = importlib.resources.read_binary(fullname, resource)
         except (FileNotFoundError, IsADirectoryError):

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -2826,9 +2826,7 @@ class ResourceForwarder(object):
         if msg.is_dead:
             return
 
-        fullname_b, resource_b = msg.unpickle()
-        fullname, resource = fullname_b.decode(), resource_b.decode()
-
+        fullname, resource = msg.unpickle()
         callback = lambda: self._on_cache_callback(msg, fullname, resource)
         self.requester._request_resource(fullname, resource, callback)
 

--- a/mitogen/service.py
+++ b/mitogen/service.py
@@ -974,14 +974,8 @@ class FileService(Service):
 
     # The IO loop pumps 128KiB chunks. An ideal message is a multiple of this,
     # odd-sized messages waste one tiny write() per message on the trailer.
-    # Therefore subtract 10 bytes pickle overhead + 24 bytes header.
-    IO_SIZE = mitogen.core.CHUNK_SIZE - (mitogen.core.Message.HEADER_LEN + (
-        len(
-            mitogen.core.Message.pickled(
-                mitogen.core.Blob(b(' ') * mitogen.core.CHUNK_SIZE)
-            ).data
-        ) - mitogen.core.CHUNK_SIZE
-    ))
+    # Therefore subtract encoding overhead and Message header size.
+    IO_SIZE = mitogen.core.CHUNK_SIZE - mitogen.core.Message.HEADER_LEN
 
     def _schedule_pending_unlocked(self, state):
         """
@@ -997,7 +991,7 @@ class FileService(Service):
             s = fp.read(self.IO_SIZE)
             if s:
                 state.unacked += len(s)
-                sender.send(mitogen.core.Blob(s))
+                sender.send(mitogen.core.Blob(s), enc=mitogen.core.Message.ENC_BIN)
             else:
                 # File is done. Cause the target's receive loop to exit by
                 # closing the sender, close the file, and remove the job entry.
@@ -1146,7 +1140,10 @@ class FileService(Service):
 
         received_bytes = 0
         for chunk in recv:
-            s = chunk.unpickle()
+            if chunk.dataenc == mitogen.core.Message.ENC_BIN:
+                s = chunk.data
+            else:
+                s = chunk.unpickle()
             LOG.debug('get_file(%r): received %d bytes', path, len(s))
             context.call_service_async(
                 service_name=cls.name(),

--- a/tests/bench/throughput.py
+++ b/tests/bench/throughput.py
@@ -63,7 +63,7 @@ def main(router):
     parser.add_option('--debug', action='store_true')
     opts, args = parser.parse_args()
 
-    ansible_mitogen.affinity.policy.assign_muxprocess()
+    #ansible_mitogen.affinity.policy.assign_muxprocess()
 
     bigfile = tempfile.NamedTemporaryFile()
     fill_with_random(bigfile, 1048576*512)
@@ -77,9 +77,9 @@ def main(router):
         run_test(router, bigfile, 'local()', context)
         context.shutdown(wait=True)
 
-        context = router.sudo(username=opts.sudo_user, debug=opts.debug)
-        run_test(router, bigfile, 'sudo()', context)
-        context.shutdown(wait=True)
+        #context = router.sudo(username=opts.sudo_user, debug=opts.debug)
+        #run_test(router, bigfile, 'sudo()', context)
+        #context.shutdown(wait=True)
 
         context = router.ssh(
             hostname=args[0],

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -78,7 +78,7 @@ class PackTest(testlib.TestCase):
     def test_magic(self):
         s = self.klass(dst_id=123, handle=123).pack()
         magic, = struct.unpack('>h', s[:2])
-        self.assertEqual(self.klass.HEADER_MAGIC, magic)
+        self.assertEqual(self.klass.HEADER_SIG, magic)
 
     def test_dst_id(self):
         s = self.klass(dst_id=123, handle=123).pack()


### PR DESCRIPTION
Alternative/complement to #1416, attempts to address #485

### Before
```console
➜  mitogen git:(master) ✗ .venv/bin/python tests/bench/throughput.py --ssh-user root pve.lan
Testing local()...
local() took 2826.54 ms to transfer 512.00 MiB, 181.14 MiB/s
Testing ssh(compression=False)...
ssh(compression=False) took 32575.41 ms to transfer 512.00 MiB, 15.72 MiB/s
Testing ssh(compression=True)...
ssh(compression=True) took 43539.39 ms to transfer 512.00 MiB, 11.76 MiB/s
```

### After
```console
➜  mitogen git:(message-dataenc) ✗ .venv/bin/python tests/bench/throughput.py --ssh-user root pve.lan
Testing local()...
local() took 246.82 ms to transfer 512.00 MiB, 2074.35 MiB/s
Testing ssh(compression=False)...
ssh(compression=False) took 22820.97 ms to transfer 512.00 MiB, 22.44 MiB/s
Testing ssh(compression=True)...
ssh(compression=True) took 21746.61 ms to transfer 512.00 MiB, 23.54 MiB/s
```