### PR TITLE
mitogen: Pickle GET_REQUEST as textual strings (2.x: unicode, 3.x: str)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,9 @@ To avail of fixes in an unreleased version, please download a ZIP file
 In progress (unreleased)
 ------------------------
 
+* :gh:issue:`1430` :mod:`mitogen`: Pickle :data:`mitogen.core.GET_RESOURCE`
+  parameters directly as textual strings (rather than ASCII in byte strings)
+
 
 v0.3.38 (2026-01-23)
 --------------------

--- a/mitogen/core.py
+++ b/mitogen/core.py
@@ -1771,7 +1771,7 @@ class ResourceRequester(object):
                 else:
                     self._callbacks[(fullname, resource)] = [callback]
                     msg = Message.pickled(
-                        (b(fullname), b(resource)),
+                        (fullname, resource),
                         handle=GET_RESOURCE,
                     )
                     self._context.send(msg)

--- a/mitogen/master.py
+++ b/mitogen/master.py
@@ -1295,8 +1295,7 @@ class ResourceResponder(object):
         stream = self._router.stream_by_id(msg.src_id)
         if stream is None:
             return
-        fullname_b, resource_b = msg.unpickle()
-        fullname, resource = fullname_b.decode(), resource_b.decode()
+        fullname, resource = msg.unpickle()
         try:
             content = importlib.resources.read_binary(fullname, resource)
         except (FileNotFoundError, IsADirectoryError):

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -2826,9 +2826,7 @@ class ResourceForwarder(object):
         if msg.is_dead:
             return
 
-        fullname_b, resource_b = msg.unpickle()
-        fullname, resource = fullname_b.decode(), resource_b.decode()
-
+        fullname, resource = msg.unpickle()
         callback = lambda: self._on_cache_callback(msg, fullname, resource)
         self.requester._request_resource(fullname, resource, callback)
 


### PR DESCRIPTION
Pickle handles encoding of unicode itself, there's no need to manually do it and when using Pickle protocol 2 byte strings are inefficient going between Python 2.x and 3.x.

refs #1430