### PR TITLE
mitogen: Consolidate pickle imports and polyfills

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,9 @@ To avail of fixes in an unreleased version, please download a ZIP file
 In progress (unreleased)
 ------------------------
 
+* :gh:issue:`1441` :mod:`mitogen`: Consolidate :mod:`pickle` imports and
+  backward compatibility handling.
+
 
 v0.3.40 (2026-02-04)
 --------------------


### PR DESCRIPTION
- Removed `py_pickle` import that was a lie on Python 3.x
- Removed `pickle` import from temptation
- Removed `pickle__dumps`, standardise on `Pickler` class or factory
- Removed `Py24Pickler` when not applicable
- Decoupled handling of Python 3.x `Unpickler(..., encoding='bytes')` from `mitogen.core.Message`

fixes #1441