### PR TITLE
mitogen: Apply default deny policy to Unpickler GLOBAL opcodes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,8 @@ In progress (unreleased)
 
 * :gh:issue:`1441` :mod:`mitogen`: Consolidate :mod:`pickle` imports and
   backward compatibility handling.
+* :gh:issue:`126` :mod:`mitogen`: Switch :class:`mitogen.core.Unpickler`
+  to default deny policy when handling :data:`pickle.GLOBAL` opcode.
 
 
 v0.3.40 (2026-02-04)

--- a/mitogen/core.py
+++ b/mitogen/core.py
@@ -112,19 +112,20 @@ else:
     now = time.time
 
 if sys.version_info >= (3, 0):
-    from pickle import PicklingError, Unpickler as _Unpickler
+    from pickle import PicklingError, Unpickler as _Unpickler, UnpicklingError
+    def find_deny(module, name):
+        raise UnpicklingError('Denied: %s.%s' % (module, name))
     class Unpickler(_Unpickler):
-        def __init__(self, file, find_global):
-            self.find_global = find_global
+        def __init__(self, file, find_class=find_deny):
+            self.find_class = find_class
             super().__init__(file, encoding='bytes')
-
-        def find_class(self, module, func):
-            return self.find_global(module, func)
 else:
-    from cPickle import PicklingError, Unpickler as _Unpickler
-    def Unpickler(file, find_global):
+    from cPickle import PicklingError, Unpickler as _Unpickler, UnpicklingError
+    def find_deny(module, name):
+        raise UnpicklingError('Denied: %s.%s' % (module, name))
+    def Unpickler(file, find_class=find_deny):
         unpickler = _Unpickler(file)
-        unpickler.find_global = find_global
+        unpickler.find_global = find_class
         return unpickler
 
 if sys.version_info >= (3, 0):

--- a/tests/pickle_test.py
+++ b/tests/pickle_test.py
@@ -1,0 +1,35 @@
+from mitogen.core import BytesIO
+from mitogen.core import Pickler
+from mitogen.core import Unpickler
+from mitogen.core import UnpicklingError
+
+import testlib
+
+def dumps(obj, protocol):
+    f = BytesIO()
+    Pickler(f, protocol).dump(obj)
+    return f.getvalue()
+
+
+def find_complex(module, func):
+    if (module, func) == ('__builtin__', 'complex'): return complex
+    raise UnpicklingError
+
+
+class UnpicklerTest(testlib.TestCase):
+    # These types have no dedicated pickle opcodes at this protocol, they use
+    # GLOBAL which invokes find_global() or find_class() during unpickling.
+    pickled_complex = dumps(1j, protocol=2)
+    pickled_frozenset = dumps(frozenset([1]), protocol=2)
+
+    def test_default_denies(self):
+        unpickler = Unpickler(BytesIO(self.pickled_complex))
+        self.assertRaises(UnpicklingError, unpickler.load)
+
+    def test_explicit_callback_allows(self):
+        unpickler = Unpickler(BytesIO(self.pickled_complex), find_complex)
+        self.assertEqual(1j, unpickler.load())
+
+    def test_explicit_callback_denies(self):
+        unpickler = Unpickler(BytesIO(self.pickled_frozenset), find_complex)
+        self.assertRaises(UnpicklingError, unpickler.load)


### PR DESCRIPTION
`mitogen.core.Unpickler` (recently introduced) will no longer require an explicit `find_class`/`find_global` callback. The new default is `mitogen.core.find_deny` which denies any `(module, func)` requested.

refs #126