### PR TITLE
mitogen: Allow mutiple pickle streams in a single Message

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,6 +30,8 @@ In progress (unreleased)
   :class:`pickle.Pickler`
 * :gh:issue:`1430` :mod:`mitogen`: Remove caching of result of
   :meth:`mitogen.core.Message.unpickle`
+* :gh:issue:`1430` :mod:`mitogen`: Allow mutiple pickle streams in a single
+  :class:`mitogen.core.Message`, add :meth:`mitogen.core.Message.unpickle_iter`
 
 
 v0.3.40 (2026-02-04)

--- a/mitogen/core.py
+++ b/mitogen/core.py
@@ -920,21 +920,22 @@ class Message(object):
         raise ValueError('Invalid explicit enc: %r' % (enc,))
 
     @classmethod
-    def pickled(cls, obj, **kwargs):
+    def pickled(cls, *args, **kwargs):
         """
         Construct a pickled message, setting :attr:`data` to the serialization
-        of `obj`, and setting remaining fields using `kwargs`.
+        of each object in `args`, and setting remaining fields using `kwargs`.
 
         :returns:
             The new message.
         """
         f = BytesIO()
         p = Pickler(f, protocol=2)
-        try:
-            p.dump(obj)
-        except PicklingError:
-            e = sys.exc_info()[1]
-            p.dump(CallError(e))
+        for obj in args:
+            try:
+                p.dump(obj)
+            except PicklingError:
+                exc = sys.exc_info()[1]
+                p.dump(CallError(exc))
         return cls(enc=cls.ENC_PKL, data=f.getvalue(), **kwargs)
 
     def reply(self, msg, router=None, **kwargs):
@@ -976,7 +977,15 @@ class Message(object):
 
     def unpickle(self, throw=True, throw_dead=True):
         """
-        Unpickle :attr:`data`, optionally raising any exceptions present.
+        Return the first unpickled stream in :attr:`data`, optionally raise
+        :exc:`CallError` if the unpickled object is such.
+        """
+        return next(self.unpickle_iter(throw, throw_dead))
+
+    def unpickle_iter(self, throw=True, throw_dead=True):
+        """
+        Return an iterator of objects unpickled from :attr:`data`, optionally
+        raising any :exc:`CallError` exceptions present.
 
         :param bool throw_dead:
             If :data:`True`, raise exceptions, otherwise it is the caller's
@@ -987,7 +996,6 @@ class Message(object):
         :raises ChannelError:
             The `is_dead` field was set.
         """
-        _vv and IOLOG.debug('%r.unpickle()', self)
         if self.enc not in (self.ENC_MGC, self.ENC_PKL):
             raise ValueError(
                 'Message %r is not pickled, invalid enc=%r', self, self.enc,
@@ -995,8 +1003,9 @@ class Message(object):
         if throw_dead and self.is_dead:
             self._throw_dead()
 
-        if True:
-            unpickler = Unpickler(BytesIO(self.data), self._find_global)
+        file = BytesIO(self.data)
+        unpickler = Unpickler(file, self._find_global)
+        while file.tell() < len(self.data):
             try:
                 # Must occur off the broker thread.
                 try:
@@ -1009,11 +1018,10 @@ class Message(object):
                 e = sys.exc_info()[1]
                 raise StreamError('invalid message: %s', e)
 
-        if throw:
-            if isinstance(obj, CallError):
+            if throw and isinstance(obj, CallError):
                 raise obj
 
-        return obj
+            yield obj
 
     def __repr__(self):
         if len(self.data) > 60:


### PR DESCRIPTION
Currently a single Message can carry one pickle stream. Allowing multiple streams will enable #1444 to be used in LOAD_MODULE and LOAD_RESOURCE messages.

refs #1430