### PR TITLE
mitogen: Default to find_deny() in Message.unpickle_iter()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,8 @@ In progress (unreleased)
   :class:`mitogen.core.Message`, add :meth:`mitogen.core.Message.unpickle_iter`
 * :gh:issue:`1430` :mod:`mitogen`: Speed up :class:`mitogen.core.ResourceReader`
   using 2 pickle streams in :data:`mitogen.core.LOAD_RESOURCE` messages
+* :gh:issue:`1430` :mod:`mitogen`: Default to :func:`mitogen.core.find_deny`
+  in :meth:`mitogen.core.Message.unpickle_iter`
 
 
 v0.3.40 (2026-02-04)

--- a/tests/message_test.py
+++ b/tests/message_test.py
@@ -337,6 +337,10 @@ class UnpickleIterTest(testlib.TestCase):
         self.assertEqual(next(parts), b('abc'))
         self.assertRaises(StopIteration, next, parts)
 
+    def test_default_find_class_denies(self):
+        msg = mitogen.core.Message.pickled(1j)
+        self.assertRaises(mitogen.core.UnpicklingError, next, msg.unpickle_iter())
+
 
 class ReplyTest(testlib.TestCase):
     # getting_started.html#rpc-serialization-rules


### PR DESCRIPTION
`Message.unpickle_iter()` is a new method, so there is no backward compatbility to maintain, so better to start with a secure default.

`Message.unpickle()` should preserve existing, looser behaviour for now.

By implication `LOAD_RESOURCE` parameters `fullname` and `resource` will raise UNpicklingError is they're not a unicode. This is intended behaviour, any such type mismatch should be fixed by correcting the type.

refs #126, #1430