### PR TITLE
mitogen: Refactor Importer.{whitelist,blacklist} as ImportPolicy.{overrides,blocks,...}

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,9 @@ To avail of fixes in an unreleased version, please download a ZIP file
 In progress (unreleased)
 ------------------------
 
+* :gh:issue:`1451` :mod:`mitogen`: Refactor module whitelist & blacklist with
+  module overrides and blocks. Improve error messages for denied modules.
+
 
 v0.3.41 (2026-02-10)
 --------------------

--- a/mitogen/parent.py
+++ b/mitogen/parent.py
@@ -1498,15 +1498,17 @@ class Connection(object):
         assert self.options.max_message_size is not None
         parent_ids = mitogen.parent_ids[:]
         parent_ids.insert(0, mitogen.context_id)
+        if mitogen.is_master: import_policy = self._router.responder.policy
+        else: import_policy = self._router.importer.policy
         return {
             'parent_ids': parent_ids,
             'context_id': self.context.context_id,
             'debug': self.options.debug,
+            'import_blocks': list(import_policy.blocks),
+            'import_overrides': list(import_policy.overrides),
             'profiling': self.options.profiling,
             'unidirectional': self.options.unidirectional,
             'log_level': get_log_level(),
-            'whitelist': self._router.get_module_whitelist(),
-            'blacklist': self._router.get_module_blacklist(),
             'max_message_size': self.options.max_message_size,
             'version': mitogen.__version__,
         }
@@ -2415,16 +2417,6 @@ class Router(mitogen.core.Router):
             self._stream_by_id.pop(target_id, None)
         finally:
             self._write_lock.release()
-
-    def get_module_blacklist(self):
-        if mitogen.context_id == 0:
-            return self.responder.blacklist
-        return self.importer.master_blacklist
-
-    def get_module_whitelist(self):
-        if mitogen.context_id == 0:
-            return self.responder.whitelist
-        return self.importer.master_whitelist
 
     def allocate_id(self):
         return self.id_allocator.allocate()

--- a/tests/responder_test.py
+++ b/tests/responder_test.py
@@ -20,7 +20,8 @@ class NeutralizeMainTest(testlib.RouterMixin, testlib.TestCase):
 
     def call(self, *args, **kwargs):
         router = mock.Mock()
-        return self.klass(router).neutralize_main(*args, **kwargs)
+        policy = mock.Mock()
+        return self.klass(router, policy).neutralize_main(*args, **kwargs)
 
     def test_missing_exec_guard(self):
         path = testlib.data_path('main_with_no_exec_guard.py')
@@ -119,7 +120,8 @@ class BrokenModulesTest(testlib.TestCase):
         )
         msg.router = router
 
-        responder = mitogen.master.ModuleResponder(router)
+        policy = mock.Mock()
+        responder = mitogen.master.ModuleResponder(router, policy)
         responder._on_get_module(msg)
         self.assertEqual(1, len(router._async_route.mock_calls))
 
@@ -157,7 +159,8 @@ class BrokenModulesTest(testlib.TestCase):
         )
         msg.router = router
 
-        responder = mitogen.master.ModuleResponder(router)
+        policy = mock.Mock()
+        responder = mitogen.master.ModuleResponder(router, policy)
         responder._on_get_module(msg)
         self.assertEqual(1, len(router._async_route.mock_calls))
 


### PR DESCRIPTION
This
- Eliminates most whitelist/blacklist terminology (#808)
- Replaces lists (O(N) lookup) with sets for O(1) lookup (atleast for top level modules)
- Consolidates policy implementation in a single class
- Improves/clarifies import denial exceptions and error messages
- Eliminates some false positive denials, e.g. pkg1 denied because pkg is blacklisted

It doesn't
- change which stdlib modules are blocked (`mitogen.core.Importer.ALWAYS_BLACKLIST`)
- change what is possibly a user facing API to add overrides (`mitogen.master.ModuleResponder.whitelist_prefix()`) or blocks (`mitogen.master.ModuleResponder.whitelist_prefix()`)

refs #1451