### PR TITLE
Allow using temporary directories on filesystems mounted noexec

### DIFF
--- a/ansible_mitogen/target.py
+++ b/ansible_mitogen/target.py
@@ -72,8 +72,7 @@ LOG = logging.getLogger(__name__)
 
 MAKE_TEMP_FAILED_MSG = (
     u"Unable to find a useable temporary directory. This likely means no\n"
-    u"system-supplied TMP directory can be written to, or all directories\n"
-    u"were mounted on 'noexec' filesystems.\n"
+    u"system-supplied TMP directory can be written to.\n"
     u"\n"
     u"The following paths were tried:\n"
     u"    %(paths)s\n"
@@ -269,21 +268,11 @@ def is_good_temp_dir(path):
         return False
 
     try:
-        try:
-            os.chmod(tmp.name, int('0700', 8))
-        except OSError:
-            e = sys.exc_info()[1]
-            LOG.debug('temp dir %r unusable: chmod failed: %s', path, e)
-            return False
-
-        try:
-            # access(.., X_OK) is sufficient to detect noexec.
-            if not os.access(tmp.name, os.X_OK):
-                raise OSError('filesystem appears to be mounted noexec')
-        except OSError:
-            e = sys.exc_info()[1]
-            LOG.debug('temp dir %r unusable: %s', path, e)
-            return False
+        os.chmod(tmp.name, int('0700', 8))
+    except OSError:
+        e = sys.exc_info()[1]
+        LOG.debug('temp dir %r unusable: chmod failed: %s', path, e)
+        return False
     finally:
         tmp.close()
 
@@ -294,8 +283,8 @@ def find_good_temp_dir(candidate_temp_dirs):
     """
     Given a list of candidate temp directories extracted from ``ansible.cfg``,
     combine it with the Python-builtin list of candidate directories used by
-    :mod:`tempfile`, then iteratively try each until one is found that is both
-    writeable and executable.
+    :mod:`tempfile`, then iteratively try each until one is found that is
+    writeable.
 
     :param list candidate_temp_dirs:
         List of candidate $variable-expanded and tilde-expanded directory paths

--- a/docs/ansible_detailed.rst
+++ b/docs/ansible_detailed.rst
@@ -541,8 +541,7 @@ interpreter, its location is consistent for each account, and it is always
 privately owned by that account.
 
 During startup, the persistent remote interpreter tries the paths below until
-one is found that is writeable and lives on a filesystem with ``noexec``
-disabled:
+one is found that is writeable:
 
 1. ``$variable`` and tilde-expanded ``remote_tmp`` setting from
    ``ansible.cfg``

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,8 @@ In progress (unreleased)
 * :gh:issue:`1499` tests: Run Mitogen unittests without
   ``MITOGEN_LOG_LEVEL=debug``
 * :gh:issue:`1505` CI: Upgrade to GitHub Actions runners that use Node 24
+* :gh:issue:`1498` :mod:`ansible_mitogen`: Allow using temporary directories on
+  filesystems mounted noexec
 
 
 v0.3.45 (2026-03-30)

--- a/tests/ansible/tests/target_test.py
+++ b/tests/ansible/tests/target_test.py
@@ -100,9 +100,3 @@ class IsGoodTempDirTest(unittest.TestCase):
         os_chmod.side_effect = OSError('nope')
         with NamedTemporaryDirectory() as temp_path:
             self.assertFalse(self.func(temp_path))
-
-    @mock.patch('os.access')
-    def test_noexec(self, os_access):
-        os_access.return_value = False
-        with NamedTemporaryDirectory() as temp_path:
-            self.assertFalse(self.func(temp_path))


### PR DESCRIPTION
Neither Ansible nor Mitogen need the temporary directory to be executable. Allow using noexec temporary directories so that mitogen-ansible can be used in environments where unpriviledged users are not allowed to have directories both writable and executable.

Binary Ansible modules require the temporary directory to be executable. It's up to the user to make sure Ansible and their environement are configured correctly for this use case.

In the situation where some candidate temporary directories are executable and some are not, the first executable one is preferred, for backwards compatibility.
