### PR TITLE
CI: Upgrade to GitHub Actions runners that use Node 24

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,8 +35,8 @@ jobs:
           - tox_env: py36-m_mtg
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@v6
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -126,12 +126,12 @@ jobs:
             python_version: '3.14'
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
         if: ${{ matrix.python_version }}
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -188,8 +188,8 @@ jobs:
             python_version: '3.14'
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python_version }}
         if: ${{ matrix.python_version }}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ In progress (unreleased)
 * :gh:issue:`1499` tests: Fix uses of ``testlib.LogCapturer``
 * :gh:issue:`1499` tests: Run Mitogen unittests without
   ``MITOGEN_LOG_LEVEL=debug``
+* :gh:issue:`1505` CI: Upgrade to GitHub Actions runners that use Node 24
 
 
 v0.3.45 (2026-03-30)


### PR DESCRIPTION
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-python@v5

See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/