### PR TITLE
mitogen: Fix sudo password authentication with translated prompts

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,8 @@ In progress (unreleased)
 
 * :gh:issue:`1514` :mod:`mitogen`: Fix sudo authentication with translated
   password prompt
+* :gh:issue:`1514` :mod:`mitogen`: Handle U+00A0 NO-BREAK SPACE characters seen
+  in some translations of sudo's password prompt
 
 
 v0.3.47 (2026-04-19)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,9 @@ To avail of fixes in an unreleased version, please download a ZIP file
 In progress (unreleased)
 ------------------------
 
+* :gh:issue:`1514` :mod:`mitogen`: Fix sudo authentication with translated
+  password prompt
+
 
 v0.3.47 (2026-04-19)
 --------------------

--- a/mitogen/sudo.py
+++ b/mitogen/sudo.py
@@ -105,7 +105,8 @@ PASSWORD_PROMPT_RE = re.compile(
         r'''
         (?:%s)  # Localised "Password", e.g. "Password", "Mot de passe"
         [^:]*?  # Optional localised text, e.g. "", " for alice", " de alice"
-        :\ ?
+        :
+        (?:\ |\xc2\xa0)?  # Optional SPACE or UTF-8 encoded NO-BREAK SPACE
         \Z  # End of string, prevents repeat matches when pwfeedback echoes '*'
         ''',
     )

--- a/mitogen/sudo.py
+++ b/mitogen/sudo.py
@@ -110,7 +110,7 @@ PASSWORD_PROMPT_RE = re.compile(
         ''',
     )
     % mitogen.core.b('|').join(
-        base64.b64decode(s)
+        re.escape(base64.b64decode(s))
         for s in PASSWORD_PROMPTS
     ),
     re.IGNORECASE | re.VERBOSE,

--- a/tests/sudo_test.py
+++ b/tests/sudo_test.py
@@ -1,6 +1,45 @@
 import os
+import re
 
 import testlib
+
+import mitogen.core
+import mitogen.sudo
+
+class PasswordPromptTest(testlib.TestCase):
+    def test_matches(self):
+        # macOS 26.4.1, en_GB
+        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'Password:'))
+        # Ubuntu 24.04, sudo-ws, en_GB
+        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo] password for alex: '))
+        # Ubuntu 26.04, sudo-rs, en_GB
+        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: authenticate] Password: '))
+
+    def test_translated_matches(self):
+        # Using French translation(s) as a stand-in for all translations.
+        # RHEL 8, sudo-ws
+        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'Mot de passe de US3RN4ME:'))
+        # Ubuntu 24.04, sudo-ws, fr_FR.UTF-8
+        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo] Mot de passe de alex : '))
+        # Ubuntu 26.04, sudo-rs, fr_FR.UTF-8
+        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: authenticate] Mot de passe : '))
+
+
+class PasswordPromptInProgressTest(testlib.TestCase):
+    def test_empty_password_no_match(self):
+        "A zero length password should not match the prompt again."
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'Password:\n'))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: authenticate] Password: \n'))
+
+    def test_pwfeedback_no_match(self):
+        """
+        Enabling pwfeedback (default in Ubuntu 26.04) shouldn't cause repeated
+        matches of the prompt when '*' is echoed.
+        """
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'Password:*'))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'Password:*\n'))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: authenticate] Password: *'))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: authenticate] Password: *\n'))
 
 
 class ConstructorTest(testlib.RouterMixin, testlib.TestCase):

--- a/tests/sudo_test.py
+++ b/tests/sudo_test.py
@@ -17,6 +17,8 @@ class PasswordPromptTest(testlib.TestCase):
 
     def test_translated_matches(self):
         # Using French translation(s) as a stand-in for all translations.
+        # Debian 9, sudo-ws, LC_ALL=fr_FR.UTF-8 LANG=fr_FR.UTF-8 LANGUAGE=fr_FR.UTF-8
+        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(u'[sudo] Mot de passe de alex\N{NO-BREAK SPACE}:\N{NO-BREAK SPACE}'.encode('utf-8')))
         # RHEL 8, sudo-ws
         self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'Mot de passe de US3RN4ME:'))
         # Ubuntu 24.04, sudo-ws, fr_FR.UTF-8
@@ -30,6 +32,7 @@ class PasswordPromptInProgressTest(testlib.TestCase):
         "A zero length password should not match the prompt again."
         self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'Password:\n'))
         self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: authenticate] Password: \n'))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(u'[sudo] Mot de passe de alex\N{NO-BREAK SPACE}:\N{NO-BREAK SPACE}\n'.encode('utf-8')))
 
     def test_pwfeedback_no_match(self):
         """
@@ -40,6 +43,8 @@ class PasswordPromptInProgressTest(testlib.TestCase):
         self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'Password:*\n'))
         self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: authenticate] Password: *'))
         self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: authenticate] Password: *\n'))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(u'[sudo] Mot de passe de alex\N{NO-BREAK SPACE}:\N{NO-BREAK SPACE}*'.encode('utf-8')))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(u'[sudo] Mot de passe de alex\N{NO-BREAK SPACE}:\N{NO-BREAK SPACE}*\n'.encode('utf-8')))
 
 
 class ConstructorTest(testlib.RouterMixin, testlib.TestCase):
@@ -97,43 +102,54 @@ class ConstructorTest(testlib.RouterMixin, testlib.TestCase):
             del os.environ['PREHISTORIC_SUDO']
 
 
-# TODO: https://github.com/dw/mitogen/issues/694
-# class NonEnglishPromptTest(testlib.DockerMixin, testlib.TestCase):
-#     # Only mitogen/debian-test has a properly configured sudo.
-#     mitogen_test_distro = 'debian'
+class SudoMixin(testlib.DockerMixin):
+    def test_password_required(self):
+        ssh = self.docker_ssh(
+            username='mitogen__has_sudo',
+            password='has_sudo_password',
+        )
+        ssh.call(os.putenv, 'LANGUAGE', 'fr')
+        ssh.call(os.putenv, 'LC_ALL', 'fr_FR.UTF-8')
+        e = self.assertRaises(mitogen.core.StreamError,
+            lambda: self.router.sudo(via=ssh)
+        )
+        self.assertIn(mitogen.sudo.password_required_msg, str(e))
 
-#     def test_password_required(self):
-#         ssh = self.docker_ssh(
-#             username='mitogen__has_sudo',
-#             password='has_sudo_password',
-#         )
-#         ssh.call(os.putenv, 'LANGUAGE', 'fr')
-#         ssh.call(os.putenv, 'LC_ALL', 'fr_FR.UTF-8')
-#         e = self.assertRaises(mitogen.core.StreamError,
-#             lambda: self.router.sudo(via=ssh)
-#         )
-#         self.assertIn(mitogen.sudo.password_required_msg, str(e))
+    def test_password_incorrect(self):
+        ssh = self.docker_ssh(
+            username='mitogen__has_sudo',
+            password='has_sudo_password',
+        )
+        ssh.call(os.putenv, 'LANGUAGE', 'fr')
+        ssh.call(os.putenv, 'LC_ALL', 'fr_FR.UTF-8')
+        e = self.assertRaises(mitogen.core.StreamError,
+            lambda: self.router.sudo(via=ssh, password='x')
+        )
+        self.assertIn(mitogen.sudo.password_incorrect_msg, str(e))
 
-#     def test_password_incorrect(self):
-#         ssh = self.docker_ssh(
-#             username='mitogen__has_sudo',
-#             password='has_sudo_password',
-#         )
-#         ssh.call(os.putenv, 'LANGUAGE', 'fr')
-#         ssh.call(os.putenv, 'LC_ALL', 'fr_FR.UTF-8')
-#         e = self.assertRaises(mitogen.core.StreamError,
-#             lambda: self.router.sudo(via=ssh, password='x')
-#         )
-#         self.assertIn(mitogen.sudo.password_incorrect_msg, str(e))
+    def test_password_okay(self):
+        ssh = self.docker_ssh(
+            username='mitogen__has_sudo',
+            password='has_sudo_password',
+        )
+        ssh.call(os.putenv, 'LANGUAGE', 'fr')
+        ssh.call(os.putenv, 'LC_ALL', 'fr_FR.UTF-8')
+        e = self.assertRaises(mitogen.core.StreamError,
+            lambda: self.router.sudo(via=ssh, password='rootpassword')
+        )
+        self.assertIn(mitogen.sudo.password_incorrect_msg, str(e))
 
-#     def test_password_okay(self):
-#         ssh = self.docker_ssh(
-#             username='mitogen__has_sudo',
-#             password='has_sudo_password',
-#         )
-#         ssh.call(os.putenv, 'LANGUAGE', 'fr')
-#         ssh.call(os.putenv, 'LC_ALL', 'fr_FR.UTF-8')
-#         e = self.assertRaises(mitogen.core.StreamError,
-#             lambda: self.router.sudo(via=ssh, password='rootpassword')
-#         )
-#         self.assertIn(mitogen.sudo.password_incorrect_msg, str(e))
+
+for distro_spec in testlib.DISTRO_SPECS.split():
+    # Only debian<version>-test images have translations installed/configured
+    if not re.match('debian', distro_spec, re.IGNORECASE):
+        continue
+
+    dockerized_ssh = testlib.DockerizedSshDaemon(distro_spec)
+    klass_name = 'SudoTest%s' % (dockerized_ssh.distro.capitalize(),)
+    klass = type(
+        klass_name,
+        (SudoMixin, testlib.TestCase),
+        {'dockerized_ssh': dockerized_ssh},
+    )
+    globals()[klass_name] = klass


### PR DESCRIPTION
Translated prompts may contain whitespace, which was being ignored because mitogen.sudo.PASSWORD_PROMPT_RE is now parsed as VERBOSE. In turn this wasn't caught because there was no test coverage. Some versions of sudo-ws have shipped with translations that use NBSP in the password prompt instead SPACE, at some positions, e.g. fr_FR on Debian 9.

fixes #1514 