### PR TITLE
Fix sudo password handling when translated prompt has no ':'

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,9 @@ To avail of fixes in an unreleased version, please download a ZIP file
 In progress (unreleased)
 ------------------------
 
+* :gh:issue:`1518` :mod:`mitogen`: Fix sudo authentication when the translated
+  password prompt doesn't contain U+003A COLON
+
 
 v0.3.48 (2026-05-22)
 --------------------

--- a/mitogen/sudo.py
+++ b/mitogen/sudo.py
@@ -28,7 +28,6 @@
 
 # !mitogen: minify_safe
 
-import base64
 import logging
 import optparse
 import re
@@ -42,79 +41,18 @@ LOG = logging.getLogger(__name__)
 password_incorrect_msg = 'sudo password is incorrect'
 password_required_msg = 'sudo password is required'
 
-# These are base64-encoded UTF-8 as our existing minifier/module server
-# struggles with Unicode Python source in some (forgotten) circumstances.
-PASSWORD_PROMPTS = [
-    'cGFzc3dvcmQ=',                                              # english
-    'bG96aW5rYQ==',                                              # sr@latin.po
-    '44OR44K544Ov44O844OJ',                                      # ja.po
-    '4Kaq4Ka+4Ka44KaT4Kef4Ka+4Kaw4KeN4Kah',                      # bn.po
-    '2YPZhNmF2Kkg2KfZhNiz2LE=',                                  # ar.po
-    'cGFzYWhpdHph',                                              # eu.po
-    '0L/QsNGA0L7Qu9GM',                                          # uk.po
-    'cGFyb29s',                                                  # et.po
-    'c2FsYXNhbmE=',                                              # fi.po
-    '4Kiq4Ki+4Ki44Ki14Kiw4Kih',                                  # pa.po
-    'Y29udHJhc2lnbm8=',                                          # ia.po
-    'Zm9jYWwgZmFpcmU=',                                          # ga.po
-    '16HXodee15Q=',                                              # he.po
-    '4Kqq4Kq+4Kq44Kq14Kqw4KuN4Kqh',                              # gu.po
-    '0L/QsNGA0L7Qu9Cw',                                          # bg.po
-    '4Kyq4K2N4Kyw4Kys4K2H4Ky2IOCsuOCsmeCtjeCsleCth+CspA==',      # or.po
-    '4K6V4K6f4K614K+B4K6a4K+N4K6a4K+K4K6y4K+N',                  # ta.po
-    'cGFzc3dvcnQ=',                                              # de.po
-    '7JWU7Zi4',                                                  # ko.po
-    '0LvQvtC30LjQvdC60LA=',                                      # sr.po
-    'beG6rXQga2jhuql1',                                          # vi.po
-    'c2VuaGE=',                                                  # pt_BR.po
-    'cGFzc3dvcmQ=',                                              # it.po
-    'aGVzbG8=',                                                  # cs.po
-    '5a+G56K877ya',                                              # zh_TW.po
-    'aGVzbG8=',                                                  # sk.po
-    '4LC44LCC4LCV4LGH4LCk4LCq4LCm4LCu4LGB',                      # te.po
-    '0L/QsNGA0L7Qu9GM',                                          # kk.po
-    'aGFzxYJv',                                                  # pl.po
-    'Y29udHJhc2VueWE=',                                          # ca.po
-    'Y29udHJhc2XDsWE=',                                          # es.po
-    '4LSF4LSf4LSv4LS+4LSz4LS14LS+4LSV4LWN4LSV4LWN',              # ml.po
-    'c2VuaGE=',                                                  # pt.po
-    '5a+G56CB77ya',                                              # zh_CN.po
-    '4KSX4KWB4KSq4KWN4KSk4KS24KSs4KWN4KSm',                      # mr.po
-    'bMO2c2Vub3Jk',                                              # sv.po
-    '4YOe4YOQ4YOg4YOd4YOa4YOY',                                  # ka.po
-    '4KS24KSs4KWN4KSm4KSV4KWC4KSf',                              # hi.po
-    'YWRnYW5nc2tvZGU=',                                          # da.po
-    '4La74LeE4LeD4LeK4La04Lav4La6',                              # si.po
-    'cGFzc29yZA==',                                              # nb.po
-    'd2FjaHR3b29yZA==',                                          # nl.po
-    '4Kaq4Ka+4Ka44KaT4Kef4Ka+4Kaw4KeN4Kah',                      # bn_IN.po
-    'cGFyb2xh',                                                  # tr.po
-    '4LKX4LOB4LKq4LON4LKk4LKq4LKm',                              # kn.po
-    'c2FuZGk=',                                                  # id.po
-    '0L/QsNGA0L7Qu9GM',                                          # ru.po
-    'amVsc3rDsw==',                                              # hu.po
-    'bW90IGRlIHBhc3Nl',                                          # fr.po
-    'aXBoYXNpd2VkaQ==',                                          # zu.po
-    '4Z6W4Z624Z6A4Z+S4Z6Z4Z6f4Z6Y4Z+S4Z6E4Z624Z6P4Z+LwqDhn5Y=',  # km.po
-    '4KaX4KeB4Kaq4KeN4Kak4Ka24Kas4KeN4Kam',                      # as.po
-]
-
-
+# See https://github.com/mitogen-hq/mitogen/wiki/Sudo-notes#password-prompt
+PASSWORD_PROMPT = 'mitogen-sudo-prompt:'
 PASSWORD_PROMPT_RE = re.compile(
     mitogen.core.b(
         r'''
-        (?:%s)  # Localised "Password", e.g. "Password", "Mot de passe"
-        [^:]*?  # Optional localised text, e.g. "", " for alice", " de alice"
-        :
-        (?:\ |\xc2\xa0)?  # Optional SPACE or UTF-8 encoded NO-BREAK SPACE
-        \Z  # End of string, prevents repeat matches when pwfeedback echoes '*'
-        ''',
-    )
-    % mitogen.core.b('|').join(
-        re.escape(base64.b64decode(s))
-        for s in PASSWORD_PROMPTS
+        # sudo.ws, uses -p/--prompt argument as is.
+        mitogen-sudo-prompt:\Z
+        # sudo-rs, adds a prefix & suffix to the -p/--prompt argument.
+        | \[sudo:\ mitogen-sudo-prompt:\]\ [^*\n]{1,50}?\Z
+        '''
     ),
-    re.IGNORECASE | re.VERBOSE,
+    re.VERBOSE,
 )
 
 SUDO_OPTIONS = [
@@ -267,7 +205,11 @@ class Connection(mitogen.parent.Connection):
         # to the sudo command.
         boot_cmd = super(Connection, self).get_boot_command()
 
-        bits = [self.options.sudo_path, '-u', self.options.username]
+        bits = [
+            self.options.sudo_path,
+            '-p', PASSWORD_PROMPT,
+            '-u', self.options.username,
+        ]
         if self.options.preserve_env:
             bits += ['-E']
         if self.options.set_home:

--- a/tests/ansible/integration/stub_connections/mitogen_sudo.yml
+++ b/tests/ansible/integration/stub_connections/mitogen_sudo.yml
@@ -20,8 +20,15 @@
         out={{ out }}
 
   - assert_equal:
-      left: (out.env.ORIGINAL_ARGV|from_json)[1:9]
-      right: ['-u', 'root', '-H', '-r', 'somerole', '-t', 'sometype', '--']
+      left: (out.env.ORIGINAL_ARGV | from_json)[1:11]
+      right: [
+        -p, 'mitogen-sudo-prompt:',
+        -u, 'root',
+        -H,
+        -r, 'somerole',
+        -t, 'sometype',
+        --,
+      ]
   tags:
     - mitogen_only
     - mitogen_sudo

--- a/tests/sudo_test.py
+++ b/tests/sudo_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import os
 import re
 
@@ -7,44 +8,44 @@ import mitogen.core
 import mitogen.sudo
 
 class PasswordPromptTest(testlib.TestCase):
-    def test_matches(self):
-        # macOS 26.4.1, en_GB
-        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'Password:'))
-        # Ubuntu 24.04, sudo-ws, en_GB
-        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo] password for alex: '))
-        # Ubuntu 26.04, sudo-rs, en_GB
-        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: authenticate] Password: '))
+    def test_sudo_ws(self):
+        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'mitogen-sudo-prompt:'))
 
-    def test_translated_matches(self):
-        # Using French translation(s) as a stand-in for all translations.
-        # Debian 9, sudo-ws, LC_ALL=fr_FR.UTF-8 LANG=fr_FR.UTF-8 LANGUAGE=fr_FR.UTF-8
-        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(u'[sudo] Mot de passe de alex\N{NO-BREAK SPACE}:\N{NO-BREAK SPACE}'.encode('utf-8')))
-        # RHEL 8, sudo-ws
-        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'Mot de passe de US3RN4ME:'))
-        # Ubuntu 24.04, sudo-ws, fr_FR.UTF-8
-        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo] Mot de passe de alex : '))
-        # Ubuntu 26.04, sudo-rs, fr_FR.UTF-8
-        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: authenticate] Mot de passe : '))
+    def test_sudo_rs_en(self):
+        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: mitogen-sudo-prompt:] Password: '))
+
+    def test_sudo_rs_fr(self):
+        # macOS+Ghostty 1.3.1-> ssh -> Ubuntu 26.04+sudo-rs -> LANGUAGE=fr sudo -k -p mitogen-sudo-prompt: true
+        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(u'[sudo: mitogen-sudo-prompt:] Mot de passe\N{NO-BREAK SPACE}: '.encode('utf-8')))
+        # Possible future variation of translation
+        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: mitogen-sudo-prompt:] Mot de passe : '))
+
+    def test_sudo_rs_zh_CN(self):
+        # macOS+Ghostty 1.3.1-> ssh -> Ubuntu 26.04+sudo-rs -> LANGUAGE=zh_CN sudo -k -p mitogen-sudo-prompt: true
+        self.assertTrue(mitogen.sudo.PASSWORD_PROMPT_RE.search(u'[sudo: mitogen-sudo-prompt:] 密码： '.encode('utf-8')))
 
 
 class PasswordPromptInProgressTest(testlib.TestCase):
     def test_empty_password_no_match(self):
         "A zero length password should not match the prompt again."
-        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'Password:\n'))
-        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: authenticate] Password: \n'))
-        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(u'[sudo] Mot de passe de alex\N{NO-BREAK SPACE}:\N{NO-BREAK SPACE}\n'.encode('utf-8')))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'mitogen-sudo-prompt:\n'))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(u'[sudo: mitogen-sudo-prompt:] Mot de passe\N{NO-BREAK SPACE}: \n'.encode('utf-8')))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: mitogen-sudo-prompt:] Mot de passe : \n'))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(u'[sudo: mitogen-sudo-prompt:] 密码： \n'.encode('utf-8')))
 
     def test_pwfeedback_no_match(self):
         """
         Enabling pwfeedback (default in Ubuntu 26.04) shouldn't cause repeated
         matches of the prompt when '*' is echoed.
         """
-        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'Password:*'))
-        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'Password:*\n'))
-        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: authenticate] Password: *'))
-        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: authenticate] Password: *\n'))
-        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(u'[sudo] Mot de passe de alex\N{NO-BREAK SPACE}:\N{NO-BREAK SPACE}*'.encode('utf-8')))
-        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(u'[sudo] Mot de passe de alex\N{NO-BREAK SPACE}:\N{NO-BREAK SPACE}*\n'.encode('utf-8')))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'mitogen-sudo-prompt:*'))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'mitogen-sudo-prompt:*\n'))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(u'[sudo: mitogen-sudo-prompt:] Mot de passe\N{NO-BREAK SPACE}: *'.encode('utf-8')))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(u'[sudo: mitogen-sudo-prompt:] Mot de passe\N{NO-BREAK SPACE}: *\n'.encode('utf-8')))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: mitogen-sudo-prompt:] Mot de passe : *'))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(b'[sudo: mitogen-sudo-prompt:] Mot de passe : *\n'))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(u'[sudo: mitogen-sudo-prompt:] 密码： *'.encode('utf-8')))
+        self.assertIsNone(mitogen.sudo.PASSWORD_PROMPT_RE.search(u'[sudo: mitogen-sudo-prompt:] 密码： *\n'.encode('utf-8')))
 
 
 class ConstructorTest(testlib.RouterMixin, testlib.TestCase):
@@ -58,39 +59,44 @@ class ConstructorTest(testlib.RouterMixin, testlib.TestCase):
         argv = eval(context.call(os.getenv, 'ORIGINAL_ARGV'))
         return context, argv
 
-
     def test_basic(self):
         context, argv = self.run_sudo()
-        self.assertEqual(argv[:4], [
+        expected_argv_tail = [
             self.sudo_path,
+            '-p', 'mitogen-sudo-prompt:',
             '-u', 'root',
             '--'
-        ])
+        ]
+        self.assertEqual(argv[:len(expected_argv_tail)], expected_argv_tail)
 
     def test_selinux_type_role(self):
         context, argv = self.run_sudo(
             selinux_type='setype',
             selinux_role='serole',
         )
-        self.assertEqual(argv[:8], [
+        expected_argv_tail = [
             self.sudo_path,
+            '-p', 'mitogen-sudo-prompt:',
             '-u', 'root',
             '-r', 'serole',
             '-t', 'setype',
             '--'
-        ])
+        ]
+        self.assertEqual(argv[:len(expected_argv_tail)], expected_argv_tail)
 
     def test_reparse_args(self):
         context, argv = self.run_sudo(
             sudo_args=['--type', 'setype', '--role', 'serole', '--user', 'user']
         )
-        self.assertEqual(argv[:8], [
+        expected_argv_tail = [
             self.sudo_path,
+            '-p', 'mitogen-sudo-prompt:',
             '-u', 'user',
             '-r', 'serole',
             '-t', 'setype',
             '--'
-        ])
+        ]
+        self.assertEqual(argv[:len(expected_argv_tail)], expected_argv_tail)
 
     def test_tty_preserved(self):
         # issue #481


### PR DESCRIPTION
Fixes #1518