### PR TITLE
Fix typos: overriden -> overridden, seperate -> separate

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -243,7 +243,7 @@ v0.3.32 (2025-11-21)
 --------------------
 
 * :gh:issue:`1243` :mod:`mitogen`: Pass first stage, context name, & preamble
-  size as seperate **argv** arguments
+  size as separate **argv** arguments
 * :gh:issue:`1218` :mod:`ansible_mitogen`: Remove maximum Ansible version check
 * :gh:issue:`1260` CI: Remove integration of retired lgtm.com
 

--- a/mitogen/core.py
+++ b/mitogen/core.py
@@ -1307,7 +1307,7 @@ class ImportPolicy(object):
     :param overrides:
         Prefixes always requested, ignoring local versions. If ``overrides``
         has entries, then it's also used as an allow list by the responder -
-        any request for a prefix that's not overriden will be denied.
+        any request for a prefix that's not overridden will be denied.
 
     :param blocks:
         Prefixes always denied by the responder, only local versions can be
@@ -1330,7 +1330,7 @@ class ImportPolicy(object):
         denial = self.denied(fullname)
         if denial: raise denial(denial.fmt % (fullname,))
 
-    def overriden(self, fullname):
+    def overridden(self, fullname):
         return bool(self.overrides.intersection(module_lineage(fullname)))
 
     def __repr__(self):
@@ -1494,7 +1494,7 @@ class Importer(object):
                 self._log.debug('%s has no submodule %s', pkgname, suffix)
                 return None
 
-            if self.policy.overriden(fullname):
+if self.policy.overridden(fullname):
                 return self
 
             try:
@@ -1541,8 +1541,8 @@ class Importer(object):
                       fullname, pkgname, pkg_loader)
             return None
 
-        if self.policy.overriden(fullname):
-            log.debug('Handling %s. It is overriden', fullname)
+        if self.policy.overridden(fullname):
+            log.debug('Handling %s. It is overridden', fullname)
             return importlib.machinery.ModuleSpec(fullname, loader=self)
 
         if fullname == '__main__':


### PR DESCRIPTION
Found a few typos in mitogen/core.py and docs/changelog.rst:overriden should be overridden (appears in method name, docstring, log message, and call sites)seperate should be separate (in changelog)