### PR TITLE
ansible_mitogen: Force-fork dnf5 module

### DIFF
--- a/ansible_mitogen/planner.py
+++ b/ansible_mitogen/planner.py
@@ -345,6 +345,9 @@ class NewStylePlanner(ScriptPlanner):
         'firewalld',  # issue #570: ansible module_utils caches dbus conn
         'ansible.legacy.dnf',  # issue #776
         'ansible.builtin.dnf', # issue #832
+        'dnf5',  # issue #1077; libdnf5 GlobalLogger is a process-global singleton
+        'ansible.legacy.dnf5',
+        'ansible.builtin.dnf5',
         'freeipa.ansible_freeipa.ipaautomember', # issue #1216
         'freeipa.ansible_freeipa.ipaautomountkey',
         'freeipa.ansible_freeipa.ipaautomountlocation',

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,10 @@ To avail of fixes in an unreleased version, please download a ZIP file
 In progress (unreleased)
 ------------------------
 
+* :gh:issue:`1077` :mod:`ansible_mitogen`: Force-fork the ``dnf5`` module so the
+  ``libdnf5`` ``GlobalLogger`` process-global singleton is not constructed twice in
+  the persistent interpreter
+
 
 v0.3.50 (2026-06-19)
 --------------------


### PR DESCRIPTION
Fedora's dnf5 module constructs libdnf5's GlobalLogger, a process-global singleton that aborts if created twice in one process. Under the persistent interpreter (mitogen_linear strategy) a second dnf5 task in the same run hits "Only one GlobalLogger can exist at a time".

ALWAYS_FORK_MODULES already force-forks the classic dnf module; add the three dnf5 forms so the dnf/dnf5 backend dispatch is covered whichever name reaches the planner, giving each task a fresh process.

Fixes https://github.com/mitogen-hq/mitogen/issues/1077